### PR TITLE
Integrate powerplantmatching

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -185,12 +185,24 @@ rule build_renewable_profiles:
     script: "scripts/build_renewable_profiles.py"
 
 
+rule build_powerplants:
+    input:
+        base_network="networks/base.nc",
+        pm_config="powerplantmatching_config.yaml",
+        custom_powerplants="data/custom_powerplants.csv"
+    output: "resources/powerplants.csv"
+    log: "logs/build_powerplants.log"
+    threads: 1
+    resources: mem=500
+    script: "scripts/build_powerplants.py"
+
+
 rule add_electricity:
     input:
         base_network='networks/base.nc',
         tech_costs=COSTS,
         regions="resources/regions_onshore.geojson",
-        # powerplants='resources/powerplants.csv',
+        powerplants='resources/powerplants.csv',
         # hydro_capacities='data/bundle/hydro_capacities.csv',
         # geth_hydro_capacities='data/geth2015_hydro_capacities.csv',
         load='resources/ssp2-2.6/2030/era5_2013/Africa.nc',

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -78,9 +78,13 @@ electricity:
     Store: [battery, H2]
     Link: []
 
+  conventional_carriers: ["OCGT", "CCGT", "oil"]
+
   max_hours:
     battery: 6
     H2: 168
+
+  powerplants_filter:
 
 lines:
   types:

--- a/configs/powerplantmatching_config.yaml
+++ b/configs/powerplantmatching_config.yaml
@@ -1,0 +1,122 @@
+# io config
+entsoe_token:
+google_api_key:
+opsd_vres_base_year: 2016
+
+
+#matching config
+matching_sources:
+  - CARMA
+  - GPD
+  - GEO
+
+fully_included_sources:
+  - CARMA
+  - GPD
+  - GEO
+
+parallel_duke_processes: false
+process_limit: 2
+remove_missing_coords: true
+
+matched_data_url:
+
+display_net_caps: true
+target_columns:
+  - Name
+  - Fueltype
+  - Technology
+  - Set
+  - Country
+  - Capacity
+  - Efficiency
+  - Duration
+  - Volume_Mm3
+  - DamHeight_m
+  - StorageCapacity_MWh
+  - DateIn
+  - DateRetrofit
+  - DateMothball
+  - DateOut
+  - lat
+  - lon
+  # - File
+  - EIC
+  - projectID
+
+target_fueltypes:
+  - Bioenergy
+  - Geothermal
+  - Hard Coal
+  - Hydro
+  - Lignite
+  - Natural Gas
+  - Nuclear
+  - Oil
+  - Other
+  - Solar
+  - Waste
+  - Wind
+  
+target_sets:
+  - CHP
+  - PP
+  - Store
+  
+target_technologies:
+  - CCGT
+  - OCGT
+  - Steam Turbine
+  - Combustion Engine
+  - Run-Of-River
+  - Pumped Storage
+  - Reservoir
+  - Marine
+  - Onshore
+  - Offshore
+  - PV
+  - CSP
+
+# heuristic config
+fuel_to_lifetime:
+    Bioenergy: 20
+    Geothermal: 15
+    Hard Coal: 45
+    Hydro: 100
+    Lignite: 45
+    Natural Gas: 40
+    Nuclear: 50
+    Oil: 40
+    Other: 5
+    Solar: 25
+    Waste: 25
+    Wind: 25
+
+# plotting config
+fuel_to_color:
+    OCGT: darkorange
+    Hydro: seagreen
+    Pumped hydro: limegreen
+    Run-of-river: navy
+    Ror: navy
+    Lignite: saddlebrown
+    Nuclear: yellow
+    Solar: gold
+    Windoff: cornflowerblue
+    Windon: darkblue
+    Offshore: cornflowerblue
+    Onshore: darkblue
+    Wind: steelblue
+    Bioenergy: g
+    Natural Gas: red
+    CCGT: red
+    Coal: k
+    Hard Coal: dimgray
+    Oil: darkgreen
+    Other: silver
+    Waste: grey
+    Geothermal: orange
+    Battery: purple
+    Hydrogen Storage: teal
+    Electro-mechanical: teal
+    Total: gold

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -27,7 +27,6 @@ dependencies:
   - yaml
   - pytables
   - lxml
-  - powerplantmatching>=0.4.8
   - numpy
   - pandas
   - geopandas
@@ -40,6 +39,7 @@ dependencies:
   - pre-commit
   - pyomo
   - matplotlib
+  - openjdk
 
   # Keep in conda environment when calling ipython
   - ipython
@@ -63,6 +63,7 @@ dependencies:
 
   - pip:
     - git+https://github.com/pypsa/pypsa.git#egg=pypsa
+    - git+https://github.com/koen-vg/powerplantmatching.git@pypsa-africa#egg=powerplantmatching
     - vresutils==0.3.1
     - tsam>=1.1.0
     - esy-osm-pbf

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -698,16 +698,16 @@ if __name__ == "__main__":
     admin_shapes = snakemake.input.gadm_shapes
 
     costs = load_costs(Nyears)
-    # ppl = load_powerplants()
+    ppl = load_powerplants()
 
     attach_load(n, regions, load, admin_shapes, countries, scale)
 
     update_transmission_costs(n, costs)
 
-    # attach_conventional_generators(n, costs, ppl)
+    attach_conventional_generators(n, costs, ppl)
     attach_wind_and_solar(n, costs)
     # attach_hydro(n, costs, ppl)
-    # attach_extendable_generators(n, costs, ppl)
+    attach_extendable_generators(n, costs, ppl)
 
     # estimate_renewable_capacities(n)
     # attach_OPSD_renewables(n)


### PR DESCRIPTION
Add a snakemake rule to generate "resources/powerplants.csv", which uses a fork of powerplantmatching. The resulting powerplants are added to the network in the "add_electricity" rule.

I will get in touch with upstream powerplantmatching to see if we can address our needs upstream, so we don't have to maintain our own fork.