### PR TITLE
Various fixing, in particular buses and lines filtering

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -37,6 +37,7 @@ datafiles = [
         "data/raw/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
         "data/raw/gebco/GEBCO_2021_TID.nc",
         "data/raw/eez/eez_v11.gpkg",
+        "data/costs.csv",
         "data/raw/landcover/WDPA_WDOECM_Oct2021_Public_AF.zip",
         "data/raw/hydrobasins/hybas_lake_af_lev04_v1c.shp",
         ]
@@ -94,6 +95,7 @@ rule build_shapes:
         # nuts3='data/bundle/NUTS_2013_60M_SH/data/NUTS_RG_60M_2013.shp',
         # nuts3pop='data/bundle/nama_10r_3popgdp.tsv.gz',
         # nuts3gdp='data/bundle/nama_10r_3gdp.tsv.gz',
+        eez='data/raw/eez/eez_v11.gpkg'
     output:
         country_shapes='resources/country_shapes.geojson',
         offshore_shapes='resources/offshore_shapes.geojson',
@@ -196,7 +198,7 @@ rule build_powerplants:
     input:
         base_network="networks/base.nc",
         pm_config="configs/powerplantmatching_config.yaml",
-        custom_powerplants="data/clean/africa_all_generators.csv"
+        custom_powerplants="data/base_network/africa_all_generators.csv"
     output: "resources/powerplants.csv"
     log: "logs/build_powerplants.log"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -38,7 +38,7 @@ datafiles = [
         "data/raw/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
         "data/raw/gebco/GEBCO_2021_TID.nc",
         "data/raw/eez/eez_v11.gpkg",
-        "data/raw/landcover/world_protected_areas/WDPA_WDOECM_Oct2021_Public_AF_shp_0/WDPA_WDOECM_Oct2021_Public_AF_shp-points.shp",
+        "data/raw/landcover",
         "data/raw/hydrobasins/hybas_lake_af_lev04_v1c.shp",
         "data/costs.csv",
         ]

--- a/Snakefile
+++ b/Snakefile
@@ -34,6 +34,7 @@ datafiles = [
         "data/raw/africa_all_raw_generators.geojson",
         "data/raw/africa_all_raw_lines.geojson",
         "data/raw/africa_all_raw_substations.geojson",
+        "data/raw/africa_all_raw_generators.csv",
         "data/raw/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
         "data/raw/gebco/GEBCO_2021_TID.nc",
         "data/raw/eez/eez_v11.gpkg",
@@ -53,6 +54,7 @@ if config['enable'].get('download_osm_data', True):
         output:
             cables="data/raw/africa_all_raw_cables.geojson",
             generators="data/raw/africa_all_raw_generators.geojson",
+            generators_csv="data/raw/africa_all_raw_generators.csv",
             lines="data/raw/africa_all_raw_lines.geojson",
             substations="data/raw/africa_all_raw_substations.geojson",
         log: "logs/download_osm_data.log"
@@ -84,6 +86,7 @@ rule build_osm_network:
     output:
         lines="data/base_network/africa_all_lines_build_network.csv",
         substations="data/base_network/africa_all_buses_build_network.csv",
+        generators="data/base_network/africa_all_generators_build_network.csv",
     log: "logs/build_osm_network.log"
     script: "scripts/osm_built_network.py"
 
@@ -198,7 +201,7 @@ rule build_powerplants:
     input:
         base_network="networks/base.nc",
         pm_config="configs/powerplantmatching_config.yaml",
-        custom_powerplants="data/base_network/africa_all_generators.csv"
+        custom_powerplants="data/raw/africa_all_raw_generators.csv"
     output: "resources/powerplants.csv"
     log: "logs/build_powerplants.log"
     threads: 1

--- a/Snakefile
+++ b/Snakefile
@@ -37,9 +37,9 @@ datafiles = [
         "data/raw/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
         "data/raw/gebco/GEBCO_2021_TID.nc",
         "data/raw/eez/eez_v11.gpkg",
-        "data/costs.csv",
-        "data/raw/landcover/WDPA_WDOECM_Oct2021_Public_AF.zip",
+        "data/raw/landcover/world_protected_areas/WDPA_WDOECM_Oct2021_Public_AF_shp_0/WDPA_WDOECM_Oct2021_Public_AF_shp-points.shp",
         "data/raw/hydrobasins/hybas_lake_af_lev04_v1c.shp",
+        "data/costs.csv",
         ]
 
 if config['enable'].get('retrieve_databundle', True):

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -59,14 +59,14 @@ snapshots:
 
 enable:
   # prepare_links_p_nom: false
-  retrieve_databundle: true
+  retrieve_databundle: false
   download_osm_data: true
   # retrieve_cutout: true
   # retrieve_natura_raster: true
   # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to
   # More information https://atlite.readthedocs.io/en/latest/introduction.html#datasets
   build_cutout: false
-  build_natura_raster: true  # If True, then build_natura_raster can be run
+  build_natura_raster: false  # If True, then build_natura_raster can be run
   # custom_busmap: false
 
 electricity:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -38,6 +38,8 @@ osm_data_cleaning_options:
   names_by_shapes: True  # Set the country name based on the extended country shapes
   threshold_voltage: 35000  # [V] minimum voltage threshold to keep the asset (cable, line, generator, etc.) [V]
   tag_substation: "transmission"  # needed feature tag to be considered for the analysis. If empty, no filtering on the tag_substation is performed
+  add_line_endings: True  # When true, the line endings are added to the dataset of the substations
+  group_close_buses: True  # When true, the dataset of buses is filtered to merge close nodes and guarantee the matching among line endings in the same bus by voltage
 
 base_network:
   min_voltage_substation_offshore: 35000  # [V] minimum voltage of the offshore substations
@@ -58,7 +60,7 @@ snapshots:
 enable:
   # prepare_links_p_nom: false
   retrieve_databundle: true
-  download_osm_data: false
+  download_osm_data: true
   # retrieve_cutout: true
   # retrieve_natura_raster: true
   # If "build_cutout" : true # requires cds API key https://cds.climate.copernicus.eu/api-how-to

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -90,7 +90,8 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import configure_logging, update_p_nom_max
+from _helpers import configure_logging
+from _helpers import update_p_nom_max
 from osm_pbf_power_data_extractor import create_country_list
 from powerplantmatching.export import map_country_bus
 from vresutils import transfer as vtransfer

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -81,7 +81,6 @@ It further adds extendable ``generators`` with **zero** capacity for
 - photovoltaic, onshore and AC- as well as DC-connected offshore wind installations with today's locational, hourly wind and solar capacity factors (but **no** current capacities),
 - additional open- and combined-cycle gas turbines (if ``OCGT`` and/or ``CCGT`` is listed in the config setting ``electricity: extendable_carriers``)
 """
-
 import logging
 import os
 
@@ -91,7 +90,8 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import configure_logging, update_p_nom_max
+from _helpers import configure_logging
+from _helpers import update_p_nom_max
 from osm_pbf_power_data_extractor import create_country_list
 from powerplantmatching.export import map_country_bus
 from vresutils import transfer as vtransfer

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -88,16 +88,15 @@ import os
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import configure_logging
-from _helpers import update_p_nom_max
+from _helpers import configure_logging, update_p_nom_max
 from osm_pbf_power_data_extractor import create_country_list
+from powerplantmatching.export import map_country_bus
 from vresutils import transfer as vtransfer
 from vresutils.costdata import annuity
 from vresutils.load import timeseries_opsd
-import powerplantmatching as pm
-from powerplantmatching.export import map_country_bus
 
 idx = pd.IndexSlice
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -173,7 +173,8 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
                                  costs.at["solar-utility", "capital_cost"])
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
-        capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
+        capital_cost = link1["capital_cost"] + \
+            max_hours * store["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
         return pd.Series(
@@ -272,10 +273,10 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
                                                normed=False).T.tocsr()
             gdp_n = pd.Series(transfer.dot(
                 shapes_cntry["gdp"].fillna(1.0).values),
-                              index=group.index)
+                index=group.index)
             pop_n = pd.Series(transfer.dot(
                 shapes_cntry["pop"].fillna(1.0).values),
-                              index=group.index)
+                index=group.index)
 
             # relative factors 0.6 and 0.4 have been determined from a linear
             # regression on the country to continent load data

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -116,8 +116,9 @@ def _add_missing_carriers_from_costs(n, costs, carriers):
     if missing_carriers.empty:
         return
 
-    emissions_cols = (costs.columns.to_series().
-                      loc[lambda s: s.str.endswith("_emissions")].values)
+    emissions_cols = (
+        costs.columns.to_series().loc[lambda s: s.str.endswith("_emissions")].values
+    )
     suptechs = missing_carriers.str.split("-").str[0]
     emissions = costs.loc[suptechs, emissions_cols].fillna(0.0)
     emissions.index = missing_carriers
@@ -136,26 +137,33 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
 
     # correct units to MW and EUR
     costs.loc[costs.unit.str.contains("/kW"), "value"] *= 1e3
-    costs.loc[costs.unit.str.contains("USD"),
-              "value"] *= config["USD2013_to_EUR2013"]
+    costs.loc[costs.unit.str.contains("USD"), "value"] *= config["USD2013_to_EUR2013"]
 
-    costs = (costs.loc[idx[:, config["year"], :], "value"].unstack(
-        level=2).groupby("technology").sum(min_count=1))
+    costs = (
+        costs.loc[idx[:, config["year"], :], "value"]
+        .unstack(level=2)
+        .groupby("technology")
+        .sum(min_count=1)
+    )
 
-    costs = costs.fillna({
-        "CO2 intensity": 0,
-        "FOM": 0,
-        "VOM": 0,
-        "discount rate": config["discountrate"],
-        "efficiency": 1,
-        "fuel": 0,
-        "investment": 0,
-        "lifetime": 25,
-    })
+    costs = costs.fillna(
+        {
+            "CO2 intensity": 0,
+            "FOM": 0,
+            "VOM": 0,
+            "discount rate": config["discountrate"],
+            "efficiency": 1,
+            "fuel": 0,
+            "investment": 0,
+            "lifetime": 25,
+        }
+    )
 
     costs["capital_cost"] = (
-        (annuity(costs["lifetime"], costs["discount rate"]) +
-         costs["FOM"] / 100.0) * costs["investment"] * Nyears)
+        (annuity(costs["lifetime"], costs["discount rate"]) + costs["FOM"] / 100.0)
+        * costs["investment"]
+        * Nyears
+    )
 
     costs.at["OCGT", "fuel"] = costs.at["gas", "fuel"]
     costs.at["CCGT", "fuel"] = costs.at["gas", "fuel"]
@@ -167,20 +175,18 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
     costs.at["OCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
     costs.at["CCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
 
-    costs.at[
-        "solar",
-        "capital_cost"] = 0.5 * (costs.at["solar-rooftop", "capital_cost"] +
-                                 costs.at["solar-utility", "capital_cost"])
+    costs.at["solar", "capital_cost"] = 0.5 * (
+        costs.at["solar-rooftop", "capital_cost"]
+        + costs.at["solar-utility", "capital_cost"]
+    )
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
-        capital_cost = link1["capital_cost"] + \
-            max_hours * store["capital_cost"]
+        capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
         return pd.Series(
-            dict(capital_cost=capital_cost,
-                 marginal_cost=0.0,
-                 co2_emissions=0.0))
+            dict(capital_cost=capital_cost, marginal_cost=0.0, co2_emissions=0.0)
+        )
 
     if elec_config is None:
         elec_config = snakemake.config["electricity"]
@@ -216,10 +222,13 @@ def load_powerplants(ppl_fn=None):
         "ccgt, thermal": "CCGT",
         "hard coal": "coal",
     }
-    return (pd.read_csv(ppl_fn, index_col=0, dtype={
-        "bus": "str"
-    }).powerplant.to_pypsa_names().rename(columns=str.lower).drop(
-        columns=["efficiency"]).replace({"carrier": carrier_dict}))
+    return (
+        pd.read_csv(ppl_fn, index_col=0, dtype={"bus": "str"})
+        .powerplant.to_pypsa_names()
+        .rename(columns=str.lower)
+        .drop(columns=["efficiency"])
+        .replace({"carrier": carrier_dict})
+    )
 
 
 def attach_load(n, regions, load, admin_shapes, countries, scale):
@@ -247,8 +256,11 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
         Now attached with load time series
     """
     substation_lv_i = n.buses.index[n.buses["substation_lv"]]
-    regions = (gpd.read_file(regions).set_index("name").reindex(
-        substation_lv_i)).dropna(axis="rows")  # Added dropna
+    regions = (
+        gpd.read_file(regions).set_index("name").reindex(substation_lv_i)
+    ).dropna(
+        axis="rows"
+    )  # Added dropna
     # "NG" had 1 out of 620 NAN shape.
     load_path = load
     gegis_load = xr.open_dataset(load_path)
@@ -262,21 +274,20 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     shapes = gpd.read_file(admin_shapes).set_index("GADM_ID")
 
     def upsample(cntry, group):
-        l = gegis_load.loc[gegis_load.region_code ==
-                           cntry]["Electricity demand"]
+        l = gegis_load.loc[gegis_load.region_code == cntry]["Electricity demand"]
         if len(group) == 1:
             return pd.DataFrame({group.index[0]: l})
         else:
             shapes_cntry = shapes.loc[shapes.country == cntry]
-            transfer = vtransfer.Shapes2Shapes(group,
-                                               shapes_cntry.geometry,
-                                               normed=False).T.tocsr()
-            gdp_n = pd.Series(transfer.dot(
-                shapes_cntry["gdp"].fillna(1.0).values),
-                index=group.index)
-            pop_n = pd.Series(transfer.dot(
-                shapes_cntry["pop"].fillna(1.0).values),
-                index=group.index)
+            transfer = vtransfer.Shapes2Shapes(
+                group, shapes_cntry.geometry, normed=False
+            ).T.tocsr()
+            gdp_n = pd.Series(
+                transfer.dot(shapes_cntry["gdp"].fillna(1.0).values), index=group.index
+            )
+            pop_n = pd.Series(
+                transfer.dot(shapes_cntry["pop"].fillna(1.0).values), index=group.index
+            )
 
             # relative factors 0.6 and 0.4 have been determined from a linear
             # regression on the country to continent load data
@@ -299,12 +310,10 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     n.madd("Load", substation_lv_i, bus=substation_lv_i, p_set=load)
 
 
-def update_transmission_costs(n,
-                              costs,
-                              length_factor=1.0,
-                              simple_hvdc_costs=False):
-    n.lines["capital_cost"] = (n.lines["length"] * length_factor *
-                               costs.at["HVAC overhead", "capital_cost"])
+def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=False):
+    n.lines["capital_cost"] = (
+        n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
+    )
 
     if n.links.empty:
         return
@@ -317,15 +326,23 @@ def update_transmission_costs(n,
         return
 
     if simple_hvdc_costs:
-        costs = (n.links.loc[dc_b, "length"] * length_factor *
-                 costs.at["HVDC overhead", "capital_cost"])
+        costs = (
+            n.links.loc[dc_b, "length"]
+            * length_factor
+            * costs.at["HVDC overhead", "capital_cost"]
+        )
     else:
-        costs = (n.links.loc[dc_b, "length"] * length_factor *
-                 ((1.0 - n.links.loc[dc_b, "underwater_fraction"]) *
-                  costs.at["HVDC overhead", "capital_cost"] +
-                  n.links.loc[dc_b, "underwater_fraction"] *
-                  costs.at["HVDC submarine", "capital_cost"]) +
-                 costs.at["HVDC inverter pair", "capital_cost"])
+        costs = (
+            n.links.loc[dc_b, "length"]
+            * length_factor
+            * (
+                (1.0 - n.links.loc[dc_b, "underwater_fraction"])
+                * costs.at["HVDC overhead", "capital_cost"]
+                + n.links.loc[dc_b, "underwater_fraction"]
+                * costs.at["HVDC submarine", "capital_cost"]
+            )
+            + costs.at["HVDC inverter pair", "capital_cost"]
+        )
     n.links.loc[dc_b, "capital_cost"] = costs
 
 
@@ -339,8 +356,7 @@ def attach_wind_and_solar(n, costs):
         # with xr.open_dataset(getattr(snakemake.input,
         #                              "profile_" + tech)) as ds:
         # TODO: Remove the 2 lines below
-        with xr.open_dataset(getattr(snakemake.input,
-                                     "profile_" + "solar")) as ds:
+        with xr.open_dataset(getattr(snakemake.input, "profile_" + "solar")) as ds:
             if ds.indexes["bus"].empty:
                 continue
 
@@ -387,12 +403,17 @@ def attach_conventional_generators(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (ppl.query("carrier in @carriers").join(
-        costs, on="carrier").rename(index=lambda s: "C" + str(s)))
+    ppl = (
+        ppl.query("carrier in @carriers")
+        .join(costs, on="carrier")
+        .rename(index=lambda s: "C" + str(s))
+    )
 
-    logger.info("Adding {} generators with capacities [MW] \n{}".format(
-        len(ppl),
-        ppl.groupby("carrier").p_nom.sum()))
+    logger.info(
+        "Adding {} generators with capacities [MW] \n{}".format(
+            len(ppl), ppl.groupby("carrier").p_nom.sum()
+        )
+    )
 
     n.madd(
         "Generator",
@@ -405,8 +426,7 @@ def attach_conventional_generators(n, costs, ppl):
         capital_cost=0,
     )
 
-    logger.warning(
-        f"Capital costs for conventional generators put to 0 EUR/MW.")
+    logger.warning(f"Capital costs for conventional generators put to 0 EUR/MW.")
 
 
 def attach_hydro(n, costs, ppl):
@@ -417,8 +437,11 @@ def attach_hydro(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (ppl.query('carrier == "hydro"').reset_index(drop=True).rename(
-        index=lambda s: str(s) + " hydro"))
+    ppl = (
+        ppl.query('carrier == "hydro"')
+        .reset_index(drop=True)
+        .rename(index=lambda s: str(s) + " hydro")
+    )
     ror = ppl.query('technology == "Run-Of-River"')
     phs = ppl.query('technology == "Pumped Storage"')
     hydro = ppl.query('technology == "Reservoir"')
@@ -427,23 +450,26 @@ def attach_hydro(n, costs, ppl):
 
     inflow_idx = ror.index.union(hydro.index)
     if not inflow_idx.empty:
-        dist_key = ppl.loc[inflow_idx,
-                           "p_nom"].groupby(country).transform(normed)
+        dist_key = ppl.loc[inflow_idx, "p_nom"].groupby(country).transform(normed)
 
         with xr.open_dataarray(snakemake.input.profile_hydro) as inflow:
             inflow_countries = pd.Index(country[inflow_idx])
             missing_c = inflow_countries.unique().difference(
-                inflow.indexes["countries"])
+                inflow.indexes["countries"]
+            )
             assert missing_c.empty, (
                 f"'{snakemake.input.profile_hydro}' is missing "
                 f"inflow time-series for at least one country: {', '.join(missing_c)}"
             )
 
-            inflow_t = (inflow.sel(countries=inflow_countries).rename({
-                "countries":
-                "name"
-            }).assign_coords(name=inflow_idx).transpose(
-                "time", "name").to_pandas().multiply(dist_key, axis=1))
+            inflow_t = (
+                inflow.sel(countries=inflow_countries)
+                .rename({"countries": "name"})
+                .assign_coords(name=inflow_idx)
+                .transpose("time", "name")
+                .to_pandas()
+                .multiply(dist_key, axis=1)
+            )
 
     if "ror" in carriers and not ror.empty:
         n.madd(
@@ -455,8 +481,11 @@ def attach_hydro(n, costs, ppl):
             efficiency=costs.at["ror", "efficiency"],
             capital_cost=costs.at["ror", "capital_cost"],
             weight=ror["p_nom"],
-            p_max_pu=(inflow_t[ror.index].divide(ror["p_nom"], axis=1).where(
-                lambda df: df <= 1.0, other=1.0)),
+            p_max_pu=(
+                inflow_t[ror.index]
+                .divide(ror["p_nom"], axis=1)
+                .where(lambda df: df <= 1.0, other=1.0)
+            ),
         )
 
     if "PHS" in carriers and not phs.empty:
@@ -478,35 +507,37 @@ def attach_hydro(n, costs, ppl):
 
     if "hydro" in carriers and not hydro.empty:
         hydro_max_hours = c.get("hydro_max_hours")
-        hydro_stats = pd.read_csv(snakemake.input.hydro_capacities,
-                                  comment="#",
-                                  na_values="-",
-                                  index_col=0)
+        hydro_stats = pd.read_csv(
+            snakemake.input.hydro_capacities, comment="#", na_values="-", index_col=0
+        )
         e_target = hydro_stats["E_store[TWh]"].clip(lower=0.2) * 1e6
-        e_installed = hydro.eval("p_nom * max_hours").groupby(
-            hydro.country).sum()
+        e_installed = hydro.eval("p_nom * max_hours").groupby(hydro.country).sum()
         e_missing = e_target - e_installed
         missing_mh_i = hydro.query("max_hours == 0").index
 
         if hydro_max_hours == "energy_capacity_totals_by_country":
             # watch out some p_nom values like IE's are totally underrepresented
             max_hours_country = (
-                e_missing /
-                hydro.loc[missing_mh_i].groupby("country").p_nom.sum())
+                e_missing / hydro.loc[missing_mh_i].groupby("country").p_nom.sum()
+            )
 
         elif hydro_max_hours == "estimate_by_large_installations":
-            max_hours_country = (hydro_stats["E_store[TWh]"] * 1e3 /
-                                 hydro_stats["p_nom_discharge[GW]"])
+            max_hours_country = (
+                hydro_stats["E_store[TWh]"] * 1e3 / hydro_stats["p_nom_discharge[GW]"]
+            )
 
         missing_countries = pd.Index(hydro["country"].unique()).difference(
-            max_hours_country.dropna().index)
+            max_hours_country.dropna().index
+        )
         if not missing_countries.empty:
             logger.warning(
-                "Assuming max_hours=6 for hydro reservoirs in the countries: {}"
-                .format(", ".join(missing_countries)))
+                "Assuming max_hours=6 for hydro reservoirs in the countries: {}".format(
+                    ", ".join(missing_countries)
+                )
+            )
         hydro_max_hours = hydro.max_hours.where(
-            hydro.max_hours > 0,
-            hydro.country.map(max_hours_country)).fillna(6)
+            hydro.max_hours > 0, hydro.country.map(max_hours_country)
+        ).fillna(6)
 
         n.madd(
             "StorageUnit",
@@ -515,8 +546,11 @@ def attach_hydro(n, costs, ppl):
             bus=hydro["bus"],
             p_nom=hydro["p_nom"],
             max_hours=hydro_max_hours,
-            capital_cost=(costs.at["hydro", "capital_cost"]
-                          if c.get("hydro_capital_cost") else 0.0),
+            capital_cost=(
+                costs.at["hydro", "capital_cost"]
+                if c.get("hydro_capital_cost")
+                else 0.0
+            ),
             marginal_cost=costs.at["hydro", "marginal_cost"],
             p_max_pu=1.0,  # dispatch
             p_min_pu=0.0,  # store
@@ -535,8 +569,11 @@ def attach_extendable_generators(n, costs, ppl):
 
     for tech in carriers:
         if tech.startswith("OCGT"):
-            ocgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
-                "bus", as_index=False).first())
+            ocgt = (
+                ppl.query("carrier in ['OCGT', 'CCGT']")
+                .groupby("bus", as_index=False)
+                .first()
+            )
             n.madd(
                 "Generator",
                 ocgt.index,
@@ -551,8 +588,11 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("CCGT"):
-            ccgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
-                "bus", as_index=False).first())
+            ccgt = (
+                ppl.query("carrier in ['OCGT', 'CCGT']")
+                .groupby("bus", as_index=False)
+                .first()
+            )
             n.madd(
                 "Generator",
                 ccgt.index,
@@ -567,8 +607,9 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("nuclear"):
-            nuclear = (ppl.query("carrier == 'nuclear'").groupby(
-                "bus", as_index=False).first())
+            nuclear = (
+                ppl.query("carrier == 'nuclear'").groupby("bus", as_index=False).first()
+            )
             n.madd(
                 "Generator",
                 nuclear.index,
@@ -586,7 +627,8 @@ def attach_extendable_generators(n, costs, ppl):
             raise NotImplementedError(
                 f"Adding extendable generators for carrier "
                 "'{tech}' is not implemented, yet. "
-                "Only OCGT, CCGT and nuclear are allowed at the moment.")
+                "Only OCGT, CCGT and nuclear are allowed at the moment."
+            )
 
 
 def attach_OPSD_renewables(n):
@@ -594,21 +636,21 @@ def attach_OPSD_renewables(n):
     available = ["DE", "FR", "PL", "CH", "DK", "CZ", "SE", "GB"]
     tech_map = {"Onshore": "onwind", "Offshore": "offwind", "Solar": "solar"}
     countries = set(available) & set(n.buses.country)
-    techs = snakemake.config["electricity"].get(
-        "renewable_capacities_from_OPSD", [])
+    techs = snakemake.config["electricity"].get("renewable_capacities_from_OPSD", [])
     tech_map = {k: v for k, v in tech_map.items() if v in techs}
 
     if not tech_map:
         return
 
-    logger.info(f'Using OPSD renewable capacities in {", ".join(countries)} '
-                f'for technologies {", ".join(tech_map.values())}.')
+    logger.info(
+        f'Using OPSD renewable capacities in {", ".join(countries)} '
+        f'for technologies {", ".join(tech_map.values())}.'
+    )
 
     df = pd.concat([pm.data.OPSD_VRE_country(c) for c in countries])
     technology_b = ~df.Technology.isin(["Onshore", "Offshore"])
     df["Fueltype"] = df.Fueltype.where(technology_b, df.Technology)
-    df = df.query(
-        "Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
+    df = df.query("Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
 
     for fueltype, carrier_like in tech_map.items():
         gens = n.generators[lambda df: df.carrier.str.contains(carrier_like)]
@@ -626,15 +668,18 @@ def attach_OPSD_renewables(n):
 def estimate_renewable_capacities(n, tech_map=None):
     if tech_map is None:
         tech_map = snakemake.config["electricity"].get(
-            "estimate_renewable_capacities_from_capacity_stats", {})
+            "estimate_renewable_capacities_from_capacity_stats", {}
+        )
 
     if len(tech_map) == 0:
         return
 
     capacities = (
-        pm.data.Capacity_stats().powerplant.convert_country_to_alpha2()
-        [lambda df: df.Energy_Source_Level_2].set_index(
-            ["Fueltype", "Country"]).sort_index())
+        pm.data.Capacity_stats()
+        .powerplant.convert_country_to_alpha2()[lambda df: df.Energy_Source_Level_2]
+        .set_index(["Fueltype", "Country"])
+        .sort_index()
+    )
 
     countries = n.buses.country.unique()
 
@@ -642,43 +687,51 @@ def estimate_renewable_capacities(n, tech_map=None):
         return
 
     logger.info(
-        "heuristics applied to distribute renewable capacities [MW] \n{}".
-        format(
-            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1"
-                             ).groupby("Country").agg({"Capacity": "sum"})))
+        "heuristics applied to distribute renewable capacities [MW] \n{}".format(
+            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1")
+            .groupby("Country")
+            .agg({"Capacity": "sum"})
+        )
+    )
 
     for ppm_fueltype, techs in tech_map.items():
-        tech_capacities = capacities.loc[ppm_fueltype,
-                                         "Capacity"].reindex(countries,
-                                                             fill_value=0.0)
+        tech_capacities = capacities.loc[ppm_fueltype, "Capacity"].reindex(
+            countries, fill_value=0.0
+        )
         # tech_i = n.generators.query('carrier in @techs').index
-        tech_i = n.generators.query("carrier in @techs")[n.generators.query(
-            "carrier in @techs").bus.map(
-                n.buses.country).isin(countries)].index
+        tech_i = n.generators.query("carrier in @techs")[
+            n.generators.query("carrier in @techs")
+            .bus.map(n.buses.country)
+            .isin(countries)
+        ].index
         n.generators.loc[tech_i, "p_nom"] = (
-            (n.generators_t.p_max_pu[tech_i].mean() *
-             n.generators.loc[tech_i, "p_nom_max"]
-             )  # maximal yearly generation
-            .groupby(n.generators.bus.map(n.buses.country)).transform(
-                lambda s: normed(s) * tech_capacities.at[s.name]).where(
-                    lambda s: s > 0.1, 0.0))  # only capacities above 100kW
-        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i,
-                                                                 "p_nom"]
+            (
+                n.generators_t.p_max_pu[tech_i].mean()
+                * n.generators.loc[tech_i, "p_nom_max"]
+            )  # maximal yearly generation
+            .groupby(n.generators.bus.map(n.buses.country))
+            .transform(lambda s: normed(s) * tech_capacities.at[s.name])
+            .where(lambda s: s > 0.1, 0.0)
+        )  # only capacities above 100kW
+        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i, "p_nom"]
 
 
 def add_nice_carrier_names(n, config=None):
     if config is None:
         config = snakemake.config
     carrier_i = n.carriers.index
-    nice_names = (pd.Series(
-        config["plotting"]["nice_names"]).reindex(carrier_i).fillna(
-            carrier_i.to_series().str.title()))
+    nice_names = (
+        pd.Series(config["plotting"]["nice_names"])
+        .reindex(carrier_i)
+        .fillna(carrier_i.to_series().str.title())
+    )
     n.carriers["nice_name"] = nice_names
     colors = pd.Series(config["plotting"]["tech_colors"]).reindex(carrier_i)
     if colors.isna().any():
         missing_i = list(colors.index[colors.isna()])
-        logger.warning(f"tech_colors for carriers {missing_i} not defined "
-                       "in config.")
+        logger.warning(
+            f"tech_colors for carriers {missing_i} not defined " "in config."
+        )
     n.carriers["color"] = colors
 
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -685,6 +685,8 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
         snakemake = mock_snakemake("add_electricity")
     configure_logging(snakemake)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -115,9 +115,8 @@ def _add_missing_carriers_from_costs(n, costs, carriers):
     if missing_carriers.empty:
         return
 
-    emissions_cols = (
-        costs.columns.to_series().loc[lambda s: s.str.endswith("_emissions")].values
-    )
+    emissions_cols = (costs.columns.to_series().
+                      loc[lambda s: s.str.endswith("_emissions")].values)
     suptechs = missing_carriers.str.split("-").str[0]
     emissions = costs.loc[suptechs, emissions_cols].fillna(0.0)
     emissions.index = missing_carriers
@@ -136,33 +135,26 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
 
     # correct units to MW and EUR
     costs.loc[costs.unit.str.contains("/kW"), "value"] *= 1e3
-    costs.loc[costs.unit.str.contains("USD"), "value"] *= config["USD2013_to_EUR2013"]
+    costs.loc[costs.unit.str.contains("USD"),
+              "value"] *= config["USD2013_to_EUR2013"]
 
-    costs = (
-        costs.loc[idx[:, config["year"], :], "value"]
-        .unstack(level=2)
-        .groupby("technology")
-        .sum(min_count=1)
-    )
+    costs = (costs.loc[idx[:, config["year"], :], "value"].unstack(
+        level=2).groupby("technology").sum(min_count=1))
 
-    costs = costs.fillna(
-        {
-            "CO2 intensity": 0,
-            "FOM": 0,
-            "VOM": 0,
-            "discount rate": config["discountrate"],
-            "efficiency": 1,
-            "fuel": 0,
-            "investment": 0,
-            "lifetime": 25,
-        }
-    )
+    costs = costs.fillna({
+        "CO2 intensity": 0,
+        "FOM": 0,
+        "VOM": 0,
+        "discount rate": config["discountrate"],
+        "efficiency": 1,
+        "fuel": 0,
+        "investment": 0,
+        "lifetime": 25,
+    })
 
     costs["capital_cost"] = (
-        (annuity(costs["lifetime"], costs["discount rate"]) + costs["FOM"] / 100.0)
-        * costs["investment"]
-        * Nyears
-    )
+        (annuity(costs["lifetime"], costs["discount rate"]) +
+         costs["FOM"] / 100.0) * costs["investment"] * Nyears)
 
     costs.at["OCGT", "fuel"] = costs.at["gas", "fuel"]
     costs.at["CCGT", "fuel"] = costs.at["gas", "fuel"]
@@ -174,18 +166,19 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
     costs.at["OCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
     costs.at["CCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
 
-    costs.at["solar", "capital_cost"] = 0.5 * (
-        costs.at["solar-rooftop", "capital_cost"]
-        + costs.at["solar-utility", "capital_cost"]
-    )
+    costs.at[
+        "solar",
+        "capital_cost"] = 0.5 * (costs.at["solar-rooftop", "capital_cost"] +
+                                 costs.at["solar-utility", "capital_cost"])
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
         capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
         return pd.Series(
-            dict(capital_cost=capital_cost, marginal_cost=0.0, co2_emissions=0.0)
-        )
+            dict(capital_cost=capital_cost,
+                 marginal_cost=0.0,
+                 co2_emissions=0.0))
 
     if elec_config is None:
         elec_config = snakemake.config["electricity"]
@@ -221,13 +214,10 @@ def load_powerplants(ppl_fn=None):
         "ccgt, thermal": "CCGT",
         "hard coal": "coal",
     }
-    return (
-        pd.read_csv(ppl_fn, index_col=0, dtype={"bus": "str"})
-        .powerplant.to_pypsa_names()
-        .rename(columns=str.lower)
-        .drop(columns=["efficiency"])
-        .replace({"carrier": carrier_dict})
-    )
+    return (pd.read_csv(ppl_fn, index_col=0, dtype={
+        "bus": "str"
+    }).powerplant.to_pypsa_names().rename(columns=str.lower).drop(
+        columns=["efficiency"]).replace({"carrier": carrier_dict}))
 
 
 def attach_load(n, regions, load, admin_shapes, countries, scale):
@@ -255,11 +245,8 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
         Now attached with load time series
     """
     substation_lv_i = n.buses.index[n.buses["substation_lv"]]
-    regions = (
-        gpd.read_file(regions).set_index("name").reindex(substation_lv_i)
-    ).dropna(
-        axis="rows"
-    )  # Added dropna
+    regions = (gpd.read_file(regions).set_index("name").reindex(
+        substation_lv_i)).dropna(axis="rows")  # Added dropna
     # "NG" had 1 out of 620 NAN shape.
     load_path = load
     gegis_load = xr.open_dataset(load_path)
@@ -273,20 +260,21 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     shapes = gpd.read_file(admin_shapes).set_index("GADM_ID")
 
     def upsample(cntry, group):
-        l = gegis_load.loc[gegis_load.region_code == cntry]["Electricity demand"]
+        l = gegis_load.loc[gegis_load.region_code ==
+                           cntry]["Electricity demand"]
         if len(group) == 1:
             return pd.DataFrame({group.index[0]: l})
         else:
             shapes_cntry = shapes.loc[shapes.country == cntry]
-            transfer = vtransfer.Shapes2Shapes(
-                group, shapes_cntry.geometry, normed=False
-            ).T.tocsr()
-            gdp_n = pd.Series(
-                transfer.dot(shapes_cntry["gdp"].fillna(1.0).values), index=group.index
-            )
-            pop_n = pd.Series(
-                transfer.dot(shapes_cntry["pop"].fillna(1.0).values), index=group.index
-            )
+            transfer = vtransfer.Shapes2Shapes(group,
+                                               shapes_cntry.geometry,
+                                               normed=False).T.tocsr()
+            gdp_n = pd.Series(transfer.dot(
+                shapes_cntry["gdp"].fillna(1.0).values),
+                              index=group.index)
+            pop_n = pd.Series(transfer.dot(
+                shapes_cntry["pop"].fillna(1.0).values),
+                              index=group.index)
 
             # relative factors 0.6 and 0.4 have been determined from a linear
             # regression on the country to continent load data
@@ -309,10 +297,12 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     n.madd("Load", substation_lv_i, bus=substation_lv_i, p_set=load)
 
 
-def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=False):
-    n.lines["capital_cost"] = (
-        n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
-    )
+def update_transmission_costs(n,
+                              costs,
+                              length_factor=1.0,
+                              simple_hvdc_costs=False):
+    n.lines["capital_cost"] = (n.lines["length"] * length_factor *
+                               costs.at["HVAC overhead", "capital_cost"])
 
     if n.links.empty:
         return
@@ -325,23 +315,15 @@ def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=Fal
         return
 
     if simple_hvdc_costs:
-        costs = (
-            n.links.loc[dc_b, "length"]
-            * length_factor
-            * costs.at["HVDC overhead", "capital_cost"]
-        )
+        costs = (n.links.loc[dc_b, "length"] * length_factor *
+                 costs.at["HVDC overhead", "capital_cost"])
     else:
-        costs = (
-            n.links.loc[dc_b, "length"]
-            * length_factor
-            * (
-                (1.0 - n.links.loc[dc_b, "underwater_fraction"])
-                * costs.at["HVDC overhead", "capital_cost"]
-                + n.links.loc[dc_b, "underwater_fraction"]
-                * costs.at["HVDC submarine", "capital_cost"]
-            )
-            + costs.at["HVDC inverter pair", "capital_cost"]
-        )
+        costs = (n.links.loc[dc_b, "length"] * length_factor *
+                 ((1.0 - n.links.loc[dc_b, "underwater_fraction"]) *
+                  costs.at["HVDC overhead", "capital_cost"] +
+                  n.links.loc[dc_b, "underwater_fraction"] *
+                  costs.at["HVDC submarine", "capital_cost"]) +
+                 costs.at["HVDC inverter pair", "capital_cost"])
     n.links.loc[dc_b, "capital_cost"] = costs
 
 
@@ -355,7 +337,8 @@ def attach_wind_and_solar(n, costs):
         # with xr.open_dataset(getattr(snakemake.input,
         #                              "profile_" + tech)) as ds:
         # TODO: Remove the 2 lines below
-        with xr.open_dataset(getattr(snakemake.input, "profile_" + "solar")) as ds:
+        with xr.open_dataset(getattr(snakemake.input,
+                                     "profile_" + "solar")) as ds:
             if ds.indexes["bus"].empty:
                 continue
 
@@ -402,17 +385,12 @@ def attach_conventional_generators(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (
-        ppl.query("carrier in @carriers")
-        .join(costs, on="carrier")
-        .rename(index=lambda s: "C" + str(s))
-    )
+    ppl = (ppl.query("carrier in @carriers").join(
+        costs, on="carrier").rename(index=lambda s: "C" + str(s)))
 
-    logger.info(
-        "Adding {} generators with capacities [MW] \n{}".format(
-            len(ppl), ppl.groupby("carrier").p_nom.sum()
-        )
-    )
+    logger.info("Adding {} generators with capacities [MW] \n{}".format(
+        len(ppl),
+        ppl.groupby("carrier").p_nom.sum()))
 
     n.madd(
         "Generator",
@@ -425,7 +403,8 @@ def attach_conventional_generators(n, costs, ppl):
         capital_cost=0,
     )
 
-    logger.warning(f"Capital costs for conventional generators put to 0 EUR/MW.")
+    logger.warning(
+        f"Capital costs for conventional generators put to 0 EUR/MW.")
 
 
 def attach_hydro(n, costs, ppl):
@@ -436,11 +415,8 @@ def attach_hydro(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (
-        ppl.query('carrier == "hydro"')
-        .reset_index(drop=True)
-        .rename(index=lambda s: str(s) + " hydro")
-    )
+    ppl = (ppl.query('carrier == "hydro"').reset_index(drop=True).rename(
+        index=lambda s: str(s) + " hydro"))
     ror = ppl.query('technology == "Run-Of-River"')
     phs = ppl.query('technology == "Pumped Storage"')
     hydro = ppl.query('technology == "Reservoir"')
@@ -449,26 +425,23 @@ def attach_hydro(n, costs, ppl):
 
     inflow_idx = ror.index.union(hydro.index)
     if not inflow_idx.empty:
-        dist_key = ppl.loc[inflow_idx, "p_nom"].groupby(country).transform(normed)
+        dist_key = ppl.loc[inflow_idx,
+                           "p_nom"].groupby(country).transform(normed)
 
         with xr.open_dataarray(snakemake.input.profile_hydro) as inflow:
             inflow_countries = pd.Index(country[inflow_idx])
             missing_c = inflow_countries.unique().difference(
-                inflow.indexes["countries"]
-            )
+                inflow.indexes["countries"])
             assert missing_c.empty, (
                 f"'{snakemake.input.profile_hydro}' is missing "
                 f"inflow time-series for at least one country: {', '.join(missing_c)}"
             )
 
-            inflow_t = (
-                inflow.sel(countries=inflow_countries)
-                .rename({"countries": "name"})
-                .assign_coords(name=inflow_idx)
-                .transpose("time", "name")
-                .to_pandas()
-                .multiply(dist_key, axis=1)
-            )
+            inflow_t = (inflow.sel(countries=inflow_countries).rename({
+                "countries":
+                "name"
+            }).assign_coords(name=inflow_idx).transpose(
+                "time", "name").to_pandas().multiply(dist_key, axis=1))
 
     if "ror" in carriers and not ror.empty:
         n.madd(
@@ -480,11 +453,8 @@ def attach_hydro(n, costs, ppl):
             efficiency=costs.at["ror", "efficiency"],
             capital_cost=costs.at["ror", "capital_cost"],
             weight=ror["p_nom"],
-            p_max_pu=(
-                inflow_t[ror.index]
-                .divide(ror["p_nom"], axis=1)
-                .where(lambda df: df <= 1.0, other=1.0)
-            ),
+            p_max_pu=(inflow_t[ror.index].divide(ror["p_nom"], axis=1).where(
+                lambda df: df <= 1.0, other=1.0)),
         )
 
     if "PHS" in carriers and not phs.empty:
@@ -506,37 +476,35 @@ def attach_hydro(n, costs, ppl):
 
     if "hydro" in carriers and not hydro.empty:
         hydro_max_hours = c.get("hydro_max_hours")
-        hydro_stats = pd.read_csv(
-            snakemake.input.hydro_capacities, comment="#", na_values="-", index_col=0
-        )
+        hydro_stats = pd.read_csv(snakemake.input.hydro_capacities,
+                                  comment="#",
+                                  na_values="-",
+                                  index_col=0)
         e_target = hydro_stats["E_store[TWh]"].clip(lower=0.2) * 1e6
-        e_installed = hydro.eval("p_nom * max_hours").groupby(hydro.country).sum()
+        e_installed = hydro.eval("p_nom * max_hours").groupby(
+            hydro.country).sum()
         e_missing = e_target - e_installed
         missing_mh_i = hydro.query("max_hours == 0").index
 
         if hydro_max_hours == "energy_capacity_totals_by_country":
             # watch out some p_nom values like IE's are totally underrepresented
             max_hours_country = (
-                e_missing / hydro.loc[missing_mh_i].groupby("country").p_nom.sum()
-            )
+                e_missing /
+                hydro.loc[missing_mh_i].groupby("country").p_nom.sum())
 
         elif hydro_max_hours == "estimate_by_large_installations":
-            max_hours_country = (
-                hydro_stats["E_store[TWh]"] * 1e3 / hydro_stats["p_nom_discharge[GW]"]
-            )
+            max_hours_country = (hydro_stats["E_store[TWh]"] * 1e3 /
+                                 hydro_stats["p_nom_discharge[GW]"])
 
         missing_countries = pd.Index(hydro["country"].unique()).difference(
-            max_hours_country.dropna().index
-        )
+            max_hours_country.dropna().index)
         if not missing_countries.empty:
             logger.warning(
-                "Assuming max_hours=6 for hydro reservoirs in the countries: {}".format(
-                    ", ".join(missing_countries)
-                )
-            )
+                "Assuming max_hours=6 for hydro reservoirs in the countries: {}"
+                .format(", ".join(missing_countries)))
         hydro_max_hours = hydro.max_hours.where(
-            hydro.max_hours > 0, hydro.country.map(max_hours_country)
-        ).fillna(6)
+            hydro.max_hours > 0,
+            hydro.country.map(max_hours_country)).fillna(6)
 
         n.madd(
             "StorageUnit",
@@ -545,11 +513,8 @@ def attach_hydro(n, costs, ppl):
             bus=hydro["bus"],
             p_nom=hydro["p_nom"],
             max_hours=hydro_max_hours,
-            capital_cost=(
-                costs.at["hydro", "capital_cost"]
-                if c.get("hydro_capital_cost")
-                else 0.0
-            ),
+            capital_cost=(costs.at["hydro", "capital_cost"]
+                          if c.get("hydro_capital_cost") else 0.0),
             marginal_cost=costs.at["hydro", "marginal_cost"],
             p_max_pu=1.0,  # dispatch
             p_min_pu=0.0,  # store
@@ -568,11 +533,8 @@ def attach_extendable_generators(n, costs, ppl):
 
     for tech in carriers:
         if tech.startswith("OCGT"):
-            ocgt = (
-                ppl.query("carrier in ['OCGT', 'CCGT']")
-                .groupby("bus", as_index=False)
-                .first()
-            )
+            ocgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
+                "bus", as_index=False).first())
             n.madd(
                 "Generator",
                 ocgt.index,
@@ -587,11 +549,8 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("CCGT"):
-            ccgt = (
-                ppl.query("carrier in ['OCGT', 'CCGT']")
-                .groupby("bus", as_index=False)
-                .first()
-            )
+            ccgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
+                "bus", as_index=False).first())
             n.madd(
                 "Generator",
                 ccgt.index,
@@ -606,9 +565,8 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("nuclear"):
-            nuclear = (
-                ppl.query("carrier == 'nuclear'").groupby("bus", as_index=False).first()
-            )
+            nuclear = (ppl.query("carrier == 'nuclear'").groupby(
+                "bus", as_index=False).first())
             n.madd(
                 "Generator",
                 nuclear.index,
@@ -626,8 +584,7 @@ def attach_extendable_generators(n, costs, ppl):
             raise NotImplementedError(
                 f"Adding extendable generators for carrier "
                 "'{tech}' is not implemented, yet. "
-                "Only OCGT, CCGT and nuclear are allowed at the moment."
-            )
+                "Only OCGT, CCGT and nuclear are allowed at the moment.")
 
 
 def attach_OPSD_renewables(n):
@@ -635,21 +592,21 @@ def attach_OPSD_renewables(n):
     available = ["DE", "FR", "PL", "CH", "DK", "CZ", "SE", "GB"]
     tech_map = {"Onshore": "onwind", "Offshore": "offwind", "Solar": "solar"}
     countries = set(available) & set(n.buses.country)
-    techs = snakemake.config["electricity"].get("renewable_capacities_from_OPSD", [])
+    techs = snakemake.config["electricity"].get(
+        "renewable_capacities_from_OPSD", [])
     tech_map = {k: v for k, v in tech_map.items() if v in techs}
 
     if not tech_map:
         return
 
-    logger.info(
-        f'Using OPSD renewable capacities in {", ".join(countries)} '
-        f'for technologies {", ".join(tech_map.values())}.'
-    )
+    logger.info(f'Using OPSD renewable capacities in {", ".join(countries)} '
+                f'for technologies {", ".join(tech_map.values())}.')
 
     df = pd.concat([pm.data.OPSD_VRE_country(c) for c in countries])
     technology_b = ~df.Technology.isin(["Onshore", "Offshore"])
     df["Fueltype"] = df.Fueltype.where(technology_b, df.Technology)
-    df = df.query("Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
+    df = df.query(
+        "Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
 
     for fueltype, carrier_like in tech_map.items():
         gens = n.generators[lambda df: df.carrier.str.contains(carrier_like)]
@@ -667,18 +624,15 @@ def attach_OPSD_renewables(n):
 def estimate_renewable_capacities(n, tech_map=None):
     if tech_map is None:
         tech_map = snakemake.config["electricity"].get(
-            "estimate_renewable_capacities_from_capacity_stats", {}
-        )
+            "estimate_renewable_capacities_from_capacity_stats", {})
 
     if len(tech_map) == 0:
         return
 
     capacities = (
-        pm.data.Capacity_stats()
-        .powerplant.convert_country_to_alpha2()[lambda df: df.Energy_Source_Level_2]
-        .set_index(["Fueltype", "Country"])
-        .sort_index()
-    )
+        pm.data.Capacity_stats().powerplant.convert_country_to_alpha2()
+        [lambda df: df.Energy_Source_Level_2].set_index(
+            ["Fueltype", "Country"]).sort_index())
 
     countries = n.buses.country.unique()
 
@@ -686,51 +640,43 @@ def estimate_renewable_capacities(n, tech_map=None):
         return
 
     logger.info(
-        "heuristics applied to distribute renewable capacities [MW] \n{}".format(
-            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1")
-            .groupby("Country")
-            .agg({"Capacity": "sum"})
-        )
-    )
+        "heuristics applied to distribute renewable capacities [MW] \n{}".
+        format(
+            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1"
+                             ).groupby("Country").agg({"Capacity": "sum"})))
 
     for ppm_fueltype, techs in tech_map.items():
-        tech_capacities = capacities.loc[ppm_fueltype, "Capacity"].reindex(
-            countries, fill_value=0.0
-        )
+        tech_capacities = capacities.loc[ppm_fueltype,
+                                         "Capacity"].reindex(countries,
+                                                             fill_value=0.0)
         # tech_i = n.generators.query('carrier in @techs').index
-        tech_i = n.generators.query("carrier in @techs")[
-            n.generators.query("carrier in @techs")
-            .bus.map(n.buses.country)
-            .isin(countries)
-        ].index
+        tech_i = n.generators.query("carrier in @techs")[n.generators.query(
+            "carrier in @techs").bus.map(
+                n.buses.country).isin(countries)].index
         n.generators.loc[tech_i, "p_nom"] = (
-            (
-                n.generators_t.p_max_pu[tech_i].mean()
-                * n.generators.loc[tech_i, "p_nom_max"]
-            )  # maximal yearly generation
-            .groupby(n.generators.bus.map(n.buses.country))
-            .transform(lambda s: normed(s) * tech_capacities.at[s.name])
-            .where(lambda s: s > 0.1, 0.0)
-        )  # only capacities above 100kW
-        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i, "p_nom"]
+            (n.generators_t.p_max_pu[tech_i].mean() *
+             n.generators.loc[tech_i, "p_nom_max"]
+             )  # maximal yearly generation
+            .groupby(n.generators.bus.map(n.buses.country)).transform(
+                lambda s: normed(s) * tech_capacities.at[s.name]).where(
+                    lambda s: s > 0.1, 0.0))  # only capacities above 100kW
+        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i,
+                                                                 "p_nom"]
 
 
 def add_nice_carrier_names(n, config=None):
     if config is None:
         config = snakemake.config
     carrier_i = n.carriers.index
-    nice_names = (
-        pd.Series(config["plotting"]["nice_names"])
-        .reindex(carrier_i)
-        .fillna(carrier_i.to_series().str.title())
-    )
+    nice_names = (pd.Series(
+        config["plotting"]["nice_names"]).reindex(carrier_i).fillna(
+            carrier_i.to_series().str.title()))
     n.carriers["nice_name"] = nice_names
     colors = pd.Series(config["plotting"]["tech_colors"]).reindex(carrier_i)
     if colors.isna().any():
         missing_i = list(colors.index[colors.isna()])
-        logger.warning(
-            f"tech_colors for carriers {missing_i} not defined " "in config."
-        )
+        logger.warning(f"tech_colors for carriers {missing_i} not defined "
+                       "in config.")
     n.carriers["color"] = colors
 
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -172,7 +172,8 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
                                  costs.at["solar-utility", "capital_cost"])
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
-        capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
+        capital_cost = link1["capital_cost"] + \
+            max_hours * store["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
         return pd.Series(
@@ -271,10 +272,10 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
                                                normed=False).T.tocsr()
             gdp_n = pd.Series(transfer.dot(
                 shapes_cntry["gdp"].fillna(1.0).values),
-                              index=group.index)
+                index=group.index)
             pop_n = pd.Series(transfer.dot(
                 shapes_cntry["pop"].fillna(1.0).values),
-                              index=group.index)
+                index=group.index)
 
             # relative factors 0.6 and 0.4 have been determined from a linear
             # regression on the country to continent load data

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -90,8 +90,7 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
-from _helpers import configure_logging
-from _helpers import update_p_nom_max
+from _helpers import configure_logging, update_p_nom_max
 from osm_pbf_power_data_extractor import create_country_list
 from powerplantmatching.export import map_country_bus
 from vresutils import transfer as vtransfer

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -115,8 +115,9 @@ def _add_missing_carriers_from_costs(n, costs, carriers):
     if missing_carriers.empty:
         return
 
-    emissions_cols = (costs.columns.to_series().
-                      loc[lambda s: s.str.endswith("_emissions")].values)
+    emissions_cols = (
+        costs.columns.to_series().loc[lambda s: s.str.endswith("_emissions")].values
+    )
     suptechs = missing_carriers.str.split("-").str[0]
     emissions = costs.loc[suptechs, emissions_cols].fillna(0.0)
     emissions.index = missing_carriers
@@ -135,26 +136,33 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
 
     # correct units to MW and EUR
     costs.loc[costs.unit.str.contains("/kW"), "value"] *= 1e3
-    costs.loc[costs.unit.str.contains("USD"),
-              "value"] *= config["USD2013_to_EUR2013"]
+    costs.loc[costs.unit.str.contains("USD"), "value"] *= config["USD2013_to_EUR2013"]
 
-    costs = (costs.loc[idx[:, config["year"], :], "value"].unstack(
-        level=2).groupby("technology").sum(min_count=1))
+    costs = (
+        costs.loc[idx[:, config["year"], :], "value"]
+        .unstack(level=2)
+        .groupby("technology")
+        .sum(min_count=1)
+    )
 
-    costs = costs.fillna({
-        "CO2 intensity": 0,
-        "FOM": 0,
-        "VOM": 0,
-        "discount rate": config["discountrate"],
-        "efficiency": 1,
-        "fuel": 0,
-        "investment": 0,
-        "lifetime": 25,
-    })
+    costs = costs.fillna(
+        {
+            "CO2 intensity": 0,
+            "FOM": 0,
+            "VOM": 0,
+            "discount rate": config["discountrate"],
+            "efficiency": 1,
+            "fuel": 0,
+            "investment": 0,
+            "lifetime": 25,
+        }
+    )
 
     costs["capital_cost"] = (
-        (annuity(costs["lifetime"], costs["discount rate"]) +
-         costs["FOM"] / 100.0) * costs["investment"] * Nyears)
+        (annuity(costs["lifetime"], costs["discount rate"]) + costs["FOM"] / 100.0)
+        * costs["investment"]
+        * Nyears
+    )
 
     costs.at["OCGT", "fuel"] = costs.at["gas", "fuel"]
     costs.at["CCGT", "fuel"] = costs.at["gas", "fuel"]
@@ -166,20 +174,18 @@ def load_costs(Nyears=1.0, tech_costs=None, config=None, elec_config=None):
     costs.at["OCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
     costs.at["CCGT", "co2_emissions"] = costs.at["gas", "co2_emissions"]
 
-    costs.at[
-        "solar",
-        "capital_cost"] = 0.5 * (costs.at["solar-rooftop", "capital_cost"] +
-                                 costs.at["solar-utility", "capital_cost"])
+    costs.at["solar", "capital_cost"] = 0.5 * (
+        costs.at["solar-rooftop", "capital_cost"]
+        + costs.at["solar-utility", "capital_cost"]
+    )
 
     def costs_for_storage(store, link1, link2=None, max_hours=1.0):
-        capital_cost = link1["capital_cost"] + \
-            max_hours * store["capital_cost"]
+        capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
         return pd.Series(
-            dict(capital_cost=capital_cost,
-                 marginal_cost=0.0,
-                 co2_emissions=0.0))
+            dict(capital_cost=capital_cost, marginal_cost=0.0, co2_emissions=0.0)
+        )
 
     if elec_config is None:
         elec_config = snakemake.config["electricity"]
@@ -215,10 +221,13 @@ def load_powerplants(ppl_fn=None):
         "ccgt, thermal": "CCGT",
         "hard coal": "coal",
     }
-    return (pd.read_csv(ppl_fn, index_col=0, dtype={
-        "bus": "str"
-    }).powerplant.to_pypsa_names().rename(columns=str.lower).drop(
-        columns=["efficiency"]).replace({"carrier": carrier_dict}))
+    return (
+        pd.read_csv(ppl_fn, index_col=0, dtype={"bus": "str"})
+        .powerplant.to_pypsa_names()
+        .rename(columns=str.lower)
+        .drop(columns=["efficiency"])
+        .replace({"carrier": carrier_dict})
+    )
 
 
 def attach_load(n, regions, load, admin_shapes, countries, scale):
@@ -246,8 +255,11 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
         Now attached with load time series
     """
     substation_lv_i = n.buses.index[n.buses["substation_lv"]]
-    regions = (gpd.read_file(regions).set_index("name").reindex(
-        substation_lv_i)).dropna(axis="rows")  # Added dropna
+    regions = (
+        gpd.read_file(regions).set_index("name").reindex(substation_lv_i)
+    ).dropna(
+        axis="rows"
+    )  # Added dropna
     # "NG" had 1 out of 620 NAN shape.
     load_path = load
     gegis_load = xr.open_dataset(load_path)
@@ -261,21 +273,20 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     shapes = gpd.read_file(admin_shapes).set_index("GADM_ID")
 
     def upsample(cntry, group):
-        l = gegis_load.loc[gegis_load.region_code ==
-                           cntry]["Electricity demand"]
+        l = gegis_load.loc[gegis_load.region_code == cntry]["Electricity demand"]
         if len(group) == 1:
             return pd.DataFrame({group.index[0]: l})
         else:
             shapes_cntry = shapes.loc[shapes.country == cntry]
-            transfer = vtransfer.Shapes2Shapes(group,
-                                               shapes_cntry.geometry,
-                                               normed=False).T.tocsr()
-            gdp_n = pd.Series(transfer.dot(
-                shapes_cntry["gdp"].fillna(1.0).values),
-                index=group.index)
-            pop_n = pd.Series(transfer.dot(
-                shapes_cntry["pop"].fillna(1.0).values),
-                index=group.index)
+            transfer = vtransfer.Shapes2Shapes(
+                group, shapes_cntry.geometry, normed=False
+            ).T.tocsr()
+            gdp_n = pd.Series(
+                transfer.dot(shapes_cntry["gdp"].fillna(1.0).values), index=group.index
+            )
+            pop_n = pd.Series(
+                transfer.dot(shapes_cntry["pop"].fillna(1.0).values), index=group.index
+            )
 
             # relative factors 0.6 and 0.4 have been determined from a linear
             # regression on the country to continent load data
@@ -298,12 +309,10 @@ def attach_load(n, regions, load, admin_shapes, countries, scale):
     n.madd("Load", substation_lv_i, bus=substation_lv_i, p_set=load)
 
 
-def update_transmission_costs(n,
-                              costs,
-                              length_factor=1.0,
-                              simple_hvdc_costs=False):
-    n.lines["capital_cost"] = (n.lines["length"] * length_factor *
-                               costs.at["HVAC overhead", "capital_cost"])
+def update_transmission_costs(n, costs, length_factor=1.0, simple_hvdc_costs=False):
+    n.lines["capital_cost"] = (
+        n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
+    )
 
     if n.links.empty:
         return
@@ -316,15 +325,23 @@ def update_transmission_costs(n,
         return
 
     if simple_hvdc_costs:
-        costs = (n.links.loc[dc_b, "length"] * length_factor *
-                 costs.at["HVDC overhead", "capital_cost"])
+        costs = (
+            n.links.loc[dc_b, "length"]
+            * length_factor
+            * costs.at["HVDC overhead", "capital_cost"]
+        )
     else:
-        costs = (n.links.loc[dc_b, "length"] * length_factor *
-                 ((1.0 - n.links.loc[dc_b, "underwater_fraction"]) *
-                  costs.at["HVDC overhead", "capital_cost"] +
-                  n.links.loc[dc_b, "underwater_fraction"] *
-                  costs.at["HVDC submarine", "capital_cost"]) +
-                 costs.at["HVDC inverter pair", "capital_cost"])
+        costs = (
+            n.links.loc[dc_b, "length"]
+            * length_factor
+            * (
+                (1.0 - n.links.loc[dc_b, "underwater_fraction"])
+                * costs.at["HVDC overhead", "capital_cost"]
+                + n.links.loc[dc_b, "underwater_fraction"]
+                * costs.at["HVDC submarine", "capital_cost"]
+            )
+            + costs.at["HVDC inverter pair", "capital_cost"]
+        )
     n.links.loc[dc_b, "capital_cost"] = costs
 
 
@@ -338,8 +355,7 @@ def attach_wind_and_solar(n, costs):
         # with xr.open_dataset(getattr(snakemake.input,
         #                              "profile_" + tech)) as ds:
         # TODO: Remove the 2 lines below
-        with xr.open_dataset(getattr(snakemake.input,
-                                     "profile_" + "solar")) as ds:
+        with xr.open_dataset(getattr(snakemake.input, "profile_" + "solar")) as ds:
             if ds.indexes["bus"].empty:
                 continue
 
@@ -386,12 +402,17 @@ def attach_conventional_generators(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (ppl.query("carrier in @carriers").join(
-        costs, on="carrier").rename(index=lambda s: "C" + str(s)))
+    ppl = (
+        ppl.query("carrier in @carriers")
+        .join(costs, on="carrier")
+        .rename(index=lambda s: "C" + str(s))
+    )
 
-    logger.info("Adding {} generators with capacities [MW] \n{}".format(
-        len(ppl),
-        ppl.groupby("carrier").p_nom.sum()))
+    logger.info(
+        "Adding {} generators with capacities [MW] \n{}".format(
+            len(ppl), ppl.groupby("carrier").p_nom.sum()
+        )
+    )
 
     n.madd(
         "Generator",
@@ -404,8 +425,7 @@ def attach_conventional_generators(n, costs, ppl):
         capital_cost=0,
     )
 
-    logger.warning(
-        f"Capital costs for conventional generators put to 0 EUR/MW.")
+    logger.warning(f"Capital costs for conventional generators put to 0 EUR/MW.")
 
 
 def attach_hydro(n, costs, ppl):
@@ -416,8 +436,11 @@ def attach_hydro(n, costs, ppl):
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
-    ppl = (ppl.query('carrier == "hydro"').reset_index(drop=True).rename(
-        index=lambda s: str(s) + " hydro"))
+    ppl = (
+        ppl.query('carrier == "hydro"')
+        .reset_index(drop=True)
+        .rename(index=lambda s: str(s) + " hydro")
+    )
     ror = ppl.query('technology == "Run-Of-River"')
     phs = ppl.query('technology == "Pumped Storage"')
     hydro = ppl.query('technology == "Reservoir"')
@@ -426,23 +449,26 @@ def attach_hydro(n, costs, ppl):
 
     inflow_idx = ror.index.union(hydro.index)
     if not inflow_idx.empty:
-        dist_key = ppl.loc[inflow_idx,
-                           "p_nom"].groupby(country).transform(normed)
+        dist_key = ppl.loc[inflow_idx, "p_nom"].groupby(country).transform(normed)
 
         with xr.open_dataarray(snakemake.input.profile_hydro) as inflow:
             inflow_countries = pd.Index(country[inflow_idx])
             missing_c = inflow_countries.unique().difference(
-                inflow.indexes["countries"])
+                inflow.indexes["countries"]
+            )
             assert missing_c.empty, (
                 f"'{snakemake.input.profile_hydro}' is missing "
                 f"inflow time-series for at least one country: {', '.join(missing_c)}"
             )
 
-            inflow_t = (inflow.sel(countries=inflow_countries).rename({
-                "countries":
-                "name"
-            }).assign_coords(name=inflow_idx).transpose(
-                "time", "name").to_pandas().multiply(dist_key, axis=1))
+            inflow_t = (
+                inflow.sel(countries=inflow_countries)
+                .rename({"countries": "name"})
+                .assign_coords(name=inflow_idx)
+                .transpose("time", "name")
+                .to_pandas()
+                .multiply(dist_key, axis=1)
+            )
 
     if "ror" in carriers and not ror.empty:
         n.madd(
@@ -454,8 +480,11 @@ def attach_hydro(n, costs, ppl):
             efficiency=costs.at["ror", "efficiency"],
             capital_cost=costs.at["ror", "capital_cost"],
             weight=ror["p_nom"],
-            p_max_pu=(inflow_t[ror.index].divide(ror["p_nom"], axis=1).where(
-                lambda df: df <= 1.0, other=1.0)),
+            p_max_pu=(
+                inflow_t[ror.index]
+                .divide(ror["p_nom"], axis=1)
+                .where(lambda df: df <= 1.0, other=1.0)
+            ),
         )
 
     if "PHS" in carriers and not phs.empty:
@@ -477,35 +506,37 @@ def attach_hydro(n, costs, ppl):
 
     if "hydro" in carriers and not hydro.empty:
         hydro_max_hours = c.get("hydro_max_hours")
-        hydro_stats = pd.read_csv(snakemake.input.hydro_capacities,
-                                  comment="#",
-                                  na_values="-",
-                                  index_col=0)
+        hydro_stats = pd.read_csv(
+            snakemake.input.hydro_capacities, comment="#", na_values="-", index_col=0
+        )
         e_target = hydro_stats["E_store[TWh]"].clip(lower=0.2) * 1e6
-        e_installed = hydro.eval("p_nom * max_hours").groupby(
-            hydro.country).sum()
+        e_installed = hydro.eval("p_nom * max_hours").groupby(hydro.country).sum()
         e_missing = e_target - e_installed
         missing_mh_i = hydro.query("max_hours == 0").index
 
         if hydro_max_hours == "energy_capacity_totals_by_country":
             # watch out some p_nom values like IE's are totally underrepresented
             max_hours_country = (
-                e_missing /
-                hydro.loc[missing_mh_i].groupby("country").p_nom.sum())
+                e_missing / hydro.loc[missing_mh_i].groupby("country").p_nom.sum()
+            )
 
         elif hydro_max_hours == "estimate_by_large_installations":
-            max_hours_country = (hydro_stats["E_store[TWh]"] * 1e3 /
-                                 hydro_stats["p_nom_discharge[GW]"])
+            max_hours_country = (
+                hydro_stats["E_store[TWh]"] * 1e3 / hydro_stats["p_nom_discharge[GW]"]
+            )
 
         missing_countries = pd.Index(hydro["country"].unique()).difference(
-            max_hours_country.dropna().index)
+            max_hours_country.dropna().index
+        )
         if not missing_countries.empty:
             logger.warning(
-                "Assuming max_hours=6 for hydro reservoirs in the countries: {}"
-                .format(", ".join(missing_countries)))
+                "Assuming max_hours=6 for hydro reservoirs in the countries: {}".format(
+                    ", ".join(missing_countries)
+                )
+            )
         hydro_max_hours = hydro.max_hours.where(
-            hydro.max_hours > 0,
-            hydro.country.map(max_hours_country)).fillna(6)
+            hydro.max_hours > 0, hydro.country.map(max_hours_country)
+        ).fillna(6)
 
         n.madd(
             "StorageUnit",
@@ -514,8 +545,11 @@ def attach_hydro(n, costs, ppl):
             bus=hydro["bus"],
             p_nom=hydro["p_nom"],
             max_hours=hydro_max_hours,
-            capital_cost=(costs.at["hydro", "capital_cost"]
-                          if c.get("hydro_capital_cost") else 0.0),
+            capital_cost=(
+                costs.at["hydro", "capital_cost"]
+                if c.get("hydro_capital_cost")
+                else 0.0
+            ),
             marginal_cost=costs.at["hydro", "marginal_cost"],
             p_max_pu=1.0,  # dispatch
             p_min_pu=0.0,  # store
@@ -534,8 +568,11 @@ def attach_extendable_generators(n, costs, ppl):
 
     for tech in carriers:
         if tech.startswith("OCGT"):
-            ocgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
-                "bus", as_index=False).first())
+            ocgt = (
+                ppl.query("carrier in ['OCGT', 'CCGT']")
+                .groupby("bus", as_index=False)
+                .first()
+            )
             n.madd(
                 "Generator",
                 ocgt.index,
@@ -550,8 +587,11 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("CCGT"):
-            ccgt = (ppl.query("carrier in ['OCGT', 'CCGT']").groupby(
-                "bus", as_index=False).first())
+            ccgt = (
+                ppl.query("carrier in ['OCGT', 'CCGT']")
+                .groupby("bus", as_index=False)
+                .first()
+            )
             n.madd(
                 "Generator",
                 ccgt.index,
@@ -566,8 +606,9 @@ def attach_extendable_generators(n, costs, ppl):
             )
 
         elif tech.startswith("nuclear"):
-            nuclear = (ppl.query("carrier == 'nuclear'").groupby(
-                "bus", as_index=False).first())
+            nuclear = (
+                ppl.query("carrier == 'nuclear'").groupby("bus", as_index=False).first()
+            )
             n.madd(
                 "Generator",
                 nuclear.index,
@@ -585,7 +626,8 @@ def attach_extendable_generators(n, costs, ppl):
             raise NotImplementedError(
                 f"Adding extendable generators for carrier "
                 "'{tech}' is not implemented, yet. "
-                "Only OCGT, CCGT and nuclear are allowed at the moment.")
+                "Only OCGT, CCGT and nuclear are allowed at the moment."
+            )
 
 
 def attach_OPSD_renewables(n):
@@ -593,21 +635,21 @@ def attach_OPSD_renewables(n):
     available = ["DE", "FR", "PL", "CH", "DK", "CZ", "SE", "GB"]
     tech_map = {"Onshore": "onwind", "Offshore": "offwind", "Solar": "solar"}
     countries = set(available) & set(n.buses.country)
-    techs = snakemake.config["electricity"].get(
-        "renewable_capacities_from_OPSD", [])
+    techs = snakemake.config["electricity"].get("renewable_capacities_from_OPSD", [])
     tech_map = {k: v for k, v in tech_map.items() if v in techs}
 
     if not tech_map:
         return
 
-    logger.info(f'Using OPSD renewable capacities in {", ".join(countries)} '
-                f'for technologies {", ".join(tech_map.values())}.')
+    logger.info(
+        f'Using OPSD renewable capacities in {", ".join(countries)} '
+        f'for technologies {", ".join(tech_map.values())}.'
+    )
 
     df = pd.concat([pm.data.OPSD_VRE_country(c) for c in countries])
     technology_b = ~df.Technology.isin(["Onshore", "Offshore"])
     df["Fueltype"] = df.Fueltype.where(technology_b, df.Technology)
-    df = df.query(
-        "Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
+    df = df.query("Fueltype in @tech_map").powerplant.convert_country_to_alpha2()
 
     for fueltype, carrier_like in tech_map.items():
         gens = n.generators[lambda df: df.carrier.str.contains(carrier_like)]
@@ -625,15 +667,18 @@ def attach_OPSD_renewables(n):
 def estimate_renewable_capacities(n, tech_map=None):
     if tech_map is None:
         tech_map = snakemake.config["electricity"].get(
-            "estimate_renewable_capacities_from_capacity_stats", {})
+            "estimate_renewable_capacities_from_capacity_stats", {}
+        )
 
     if len(tech_map) == 0:
         return
 
     capacities = (
-        pm.data.Capacity_stats().powerplant.convert_country_to_alpha2()
-        [lambda df: df.Energy_Source_Level_2].set_index(
-            ["Fueltype", "Country"]).sort_index())
+        pm.data.Capacity_stats()
+        .powerplant.convert_country_to_alpha2()[lambda df: df.Energy_Source_Level_2]
+        .set_index(["Fueltype", "Country"])
+        .sort_index()
+    )
 
     countries = n.buses.country.unique()
 
@@ -641,43 +686,51 @@ def estimate_renewable_capacities(n, tech_map=None):
         return
 
     logger.info(
-        "heuristics applied to distribute renewable capacities [MW] \n{}".
-        format(
-            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1"
-                             ).groupby("Country").agg({"Capacity": "sum"})))
+        "heuristics applied to distribute renewable capacities [MW] \n{}".format(
+            capacities.query("Fueltype in @tech_map.keys() and Capacity >= 0.1")
+            .groupby("Country")
+            .agg({"Capacity": "sum"})
+        )
+    )
 
     for ppm_fueltype, techs in tech_map.items():
-        tech_capacities = capacities.loc[ppm_fueltype,
-                                         "Capacity"].reindex(countries,
-                                                             fill_value=0.0)
+        tech_capacities = capacities.loc[ppm_fueltype, "Capacity"].reindex(
+            countries, fill_value=0.0
+        )
         # tech_i = n.generators.query('carrier in @techs').index
-        tech_i = n.generators.query("carrier in @techs")[n.generators.query(
-            "carrier in @techs").bus.map(
-                n.buses.country).isin(countries)].index
+        tech_i = n.generators.query("carrier in @techs")[
+            n.generators.query("carrier in @techs")
+            .bus.map(n.buses.country)
+            .isin(countries)
+        ].index
         n.generators.loc[tech_i, "p_nom"] = (
-            (n.generators_t.p_max_pu[tech_i].mean() *
-             n.generators.loc[tech_i, "p_nom_max"]
-             )  # maximal yearly generation
-            .groupby(n.generators.bus.map(n.buses.country)).transform(
-                lambda s: normed(s) * tech_capacities.at[s.name]).where(
-                    lambda s: s > 0.1, 0.0))  # only capacities above 100kW
-        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i,
-                                                                 "p_nom"]
+            (
+                n.generators_t.p_max_pu[tech_i].mean()
+                * n.generators.loc[tech_i, "p_nom_max"]
+            )  # maximal yearly generation
+            .groupby(n.generators.bus.map(n.buses.country))
+            .transform(lambda s: normed(s) * tech_capacities.at[s.name])
+            .where(lambda s: s > 0.1, 0.0)
+        )  # only capacities above 100kW
+        n.generators.loc[tech_i, "p_nom_min"] = n.generators.loc[tech_i, "p_nom"]
 
 
 def add_nice_carrier_names(n, config=None):
     if config is None:
         config = snakemake.config
     carrier_i = n.carriers.index
-    nice_names = (pd.Series(
-        config["plotting"]["nice_names"]).reindex(carrier_i).fillna(
-            carrier_i.to_series().str.title()))
+    nice_names = (
+        pd.Series(config["plotting"]["nice_names"])
+        .reindex(carrier_i)
+        .fillna(carrier_i.to_series().str.title())
+    )
     n.carriers["nice_name"] = nice_names
     colors = pd.Series(config["plotting"]["tech_colors"]).reindex(carrier_i)
     if colors.isna().any():
         missing_i = list(colors.index[colors.isna()])
-        logger.warning(f"tech_colors for carriers {missing_i} not defined "
-                       "in config.")
+        logger.warning(
+            f"tech_colors for carriers {missing_i} not defined " "in config."
+        )
     n.carriers["color"] = colors
 
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -55,9 +55,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import _add_missing_carriers_from_costs
-from add_electricity import add_nice_carrier_names
-from add_electricity import load_costs
+from add_electricity import (_add_missing_carriers_from_costs,
+                             add_nice_carrier_names, load_costs)
 
 idx = pd.IndexSlice
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -50,18 +50,14 @@ The rule :mod:`add_extra_components` attaches additional extendable components t
 - ``Stores`` of carrier 'H2' and/or 'battery' in combination with ``Links``. If this option is chosen, the script adds extra buses with corresponding carrier where energy ``Stores`` are attached and which are connected to the corresponding power buses via two links, one each for charging and discharging. This leads to three investment variables for the energy capacity, charging and discharging capacity of the storage unit.
 """
 import logging
-from _helpers import configure_logging
-
-import pypsa
-import pandas as pd
 import os
-import numpy as np
 
-from add_electricity import (
-    load_costs,
-    add_nice_carrier_names,
-    _add_missing_carriers_from_costs,
-)
+import numpy as np
+import pandas as pd
+import pypsa
+from _helpers import configure_logging
+from add_electricity import (_add_missing_carriers_from_costs,
+                             add_nice_carrier_names, load_costs)
 
 idx = pd.IndexSlice
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -87,8 +87,7 @@ def attach_storageunits(n, costs):
             capital_cost=costs.at[carrier, "capital_cost"],
             marginal_cost=costs.at[carrier, "marginal_cost"],
             efficiency_store=costs.at[lookup_store[carrier], "efficiency"],
-            efficiency_dispatch=costs.at[lookup_dispatch[carrier],
-                                         "efficiency"],
+            efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"],
             max_hours=max_hours[carrier],
             cyclic_state_of_charge=True,
         )
@@ -104,10 +103,7 @@ def attach_stores(n, costs):
     bus_sub_dict = {k: n.buses[k].values for k in ["x", "y", "country"]}
 
     if "H2" in carriers:
-        h2_buses_i = n.madd("Bus",
-                            buses_i + " H2",
-                            carrier="H2",
-                            **bus_sub_dict)
+        h2_buses_i = n.madd("Bus", buses_i + " H2", carrier="H2", **bus_sub_dict)
 
         n.madd(
             "Store",
@@ -140,16 +136,15 @@ def attach_stores(n, costs):
             p_nom_extendable=True,
             efficiency=costs.at["fuel cell", "efficiency"],
             # NB: fixed cost is per MWel
-            capital_cost=costs.at["fuel cell", "capital_cost"] *
-            costs.at["fuel cell", "efficiency"],
+            capital_cost=costs.at["fuel cell", "capital_cost"]
+            * costs.at["fuel cell", "efficiency"],
             marginal_cost=costs.at["fuel cell", "marginal_cost"],
         )
 
     if "battery" in carriers:
-        b_buses_i = n.madd("Bus",
-                           buses_i + " battery",
-                           carrier="battery",
-                           **bus_sub_dict)
+        b_buses_i = n.madd(
+            "Bus", buses_i + " battery", carrier="battery", **bus_sub_dict
+        )
 
         n.madd(
             "Store",
@@ -197,19 +192,20 @@ def attach_hydrogen_pipelines(n, costs):
     assert "H2" in as_stores, (
         "Attaching hydrogen pipelines requires hydrogen "
         "storage to be modelled as Store-Link-Bus combination. See "
-        "`config.yaml` at `electricity: extendable_carriers: Store:`.")
+        "`config.yaml` at `electricity: extendable_carriers: Store:`."
+    )
 
     # determine bus pairs
     attrs = ["bus0", "bus1", "length"]
     candidates = pd.concat(
-        [n.lines[attrs],
-         n.links.query('carrier=="DC"')[attrs]]).reset_index(drop=True)
+        [n.lines[attrs], n.links.query('carrier=="DC"')[attrs]]
+    ).reset_index(drop=True)
 
     # remove bus pair duplicates regardless of order of bus0 and bus1
-    h2_links = candidates[~pd.DataFrame(np.sort(candidates[["bus0", "bus1"]])).
-                          duplicated()]
-    h2_links.index = h2_links.apply(lambda c: f"H2 pipeline {c.bus0}-{c.bus1}",
-                                    axis=1)
+    h2_links = candidates[
+        ~pd.DataFrame(np.sort(candidates[["bus0", "bus1"]])).duplicated()
+    ]
+    h2_links.index = h2_links.apply(lambda c: f"H2 pipeline {c.bus0}-{c.bus1}", axis=1)
 
     # add pipelines
     n.madd(
@@ -231,10 +227,9 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake("add_extra_components",
-                                   network="elec",
-                                   simpl="",
-                                   clusters=10)
+        snakemake = mock_snakemake(
+            "add_extra_components", network="elec", simpl="", clusters=10
+        )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -54,6 +54,7 @@ from _helpers import configure_logging
 
 import pypsa
 import pandas as pd
+import os
 import numpy as np
 
 from add_electricity import (load_costs, add_nice_carrier_names,
@@ -192,8 +193,9 @@ def attach_hydrogen_pipelines(n, costs):
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from _helpers import mock_snakemake
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake('add_extra_components', network='elec',
-                                  simpl='', clusters=5)
+                                  simpl='', clusters=10)
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: : 2017-2020 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT
-
 # coding: utf-8
 """
 Adds extra extendable components to the clustered and simplified network.
@@ -56,8 +55,9 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import (_add_missing_carriers_from_costs,
-                             add_nice_carrier_names, load_costs)
+from add_electricity import _add_missing_carriers_from_costs
+from add_electricity import add_nice_carrier_names
+from add_electricity import load_costs
 
 idx = pd.IndexSlice
 

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -57,8 +57,11 @@ import pandas as pd
 import os
 import numpy as np
 
-from add_electricity import (load_costs, add_nice_carrier_names,
-                             _add_missing_carriers_from_costs)
+from add_electricity import (
+    load_costs,
+    add_nice_carrier_names,
+    _add_missing_carriers_from_costs,
+)
 
 idx = pd.IndexSlice
 
@@ -66,9 +69,9 @@ logger = logging.getLogger(__name__)
 
 
 def attach_storageunits(n, costs):
-    elec_opts = snakemake.config['electricity']
-    carriers = elec_opts['extendable_carriers']['StorageUnit']
-    max_hours = elec_opts['max_hours']
+    elec_opts = snakemake.config["electricity"]
+    carriers = elec_opts["extendable_carriers"]["StorageUnit"]
+    max_hours = elec_opts["max_hours"]
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
@@ -78,139 +81,169 @@ def attach_storageunits(n, costs):
     lookup_dispatch = {"H2": "fuel cell", "battery": "battery inverter"}
 
     for carrier in carriers:
-        n.madd("StorageUnit", buses_i, ' ' + carrier,
-               bus=buses_i,
-               carrier=carrier,
-               p_nom_extendable=True,
-               capital_cost=costs.at[carrier, 'capital_cost'],
-               marginal_cost=costs.at[carrier, 'marginal_cost'],
-               efficiency_store=costs.at[lookup_store[carrier], 'efficiency'],
-               efficiency_dispatch=costs.at[lookup_dispatch[carrier],
-                                            'efficiency'],
-               max_hours=max_hours[carrier],
-               cyclic_state_of_charge=True)
+        n.madd(
+            "StorageUnit",
+            buses_i,
+            " " + carrier,
+            bus=buses_i,
+            carrier=carrier,
+            p_nom_extendable=True,
+            capital_cost=costs.at[carrier, "capital_cost"],
+            marginal_cost=costs.at[carrier, "marginal_cost"],
+            efficiency_store=costs.at[lookup_store[carrier], "efficiency"],
+            efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"],
+            max_hours=max_hours[carrier],
+            cyclic_state_of_charge=True,
+        )
 
 
 def attach_stores(n, costs):
-    elec_opts = snakemake.config['electricity']
-    carriers = elec_opts['extendable_carriers']['Store']
+    elec_opts = snakemake.config["electricity"]
+    carriers = elec_opts["extendable_carriers"]["Store"]
 
     _add_missing_carriers_from_costs(n, costs, carriers)
 
     buses_i = n.buses.index
-    bus_sub_dict = {k: n.buses[k].values for k in ['x', 'y', 'country']}
+    bus_sub_dict = {k: n.buses[k].values for k in ["x", "y", "country"]}
 
-    if 'H2' in carriers:
-        h2_buses_i = n.madd("Bus", buses_i + " H2",
-                            carrier="H2", **bus_sub_dict)
+    if "H2" in carriers:
+        h2_buses_i = n.madd("Bus", buses_i + " H2", carrier="H2", **bus_sub_dict)
 
-        n.madd("Store", h2_buses_i,
-               bus=h2_buses_i,
-               carrier='H2',
-               e_nom_extendable=True,
-               e_cyclic=True,
-               capital_cost=costs.at["hydrogen storage", "capital_cost"])
+        n.madd(
+            "Store",
+            h2_buses_i,
+            bus=h2_buses_i,
+            carrier="H2",
+            e_nom_extendable=True,
+            e_cyclic=True,
+            capital_cost=costs.at["hydrogen storage", "capital_cost"],
+        )
 
-        n.madd("Link", h2_buses_i + " Electrolysis",
-               bus0=buses_i,
-               bus1=h2_buses_i,
-               carrier='H2 electrolysis',
-               p_nom_extendable=True,
-               efficiency=costs.at["electrolysis", "efficiency"],
-               capital_cost=costs.at["electrolysis", "capital_cost"],
-               marginal_cost=costs.at["electrolysis", "marginal_cost"])
+        n.madd(
+            "Link",
+            h2_buses_i + " Electrolysis",
+            bus0=buses_i,
+            bus1=h2_buses_i,
+            carrier="H2 electrolysis",
+            p_nom_extendable=True,
+            efficiency=costs.at["electrolysis", "efficiency"],
+            capital_cost=costs.at["electrolysis", "capital_cost"],
+            marginal_cost=costs.at["electrolysis", "marginal_cost"],
+        )
 
-        n.madd("Link", h2_buses_i + " Fuel Cell",
-               bus0=h2_buses_i,
-               bus1=buses_i,
-               carrier='H2 fuel cell',
-               p_nom_extendable=True,
-               efficiency=costs.at["fuel cell", "efficiency"],
-               # NB: fixed cost is per MWel
-               capital_cost=costs.at["fuel cell", "capital_cost"] * \
-               costs.at["fuel cell", "efficiency"],
-               marginal_cost=costs.at["fuel cell", "marginal_cost"])
+        n.madd(
+            "Link",
+            h2_buses_i + " Fuel Cell",
+            bus0=h2_buses_i,
+            bus1=buses_i,
+            carrier="H2 fuel cell",
+            p_nom_extendable=True,
+            efficiency=costs.at["fuel cell", "efficiency"],
+            # NB: fixed cost is per MWel
+            capital_cost=costs.at["fuel cell", "capital_cost"]
+            * costs.at["fuel cell", "efficiency"],
+            marginal_cost=costs.at["fuel cell", "marginal_cost"],
+        )
 
-    if 'battery' in carriers:
-        b_buses_i = n.madd("Bus", buses_i + " battery",
-                           carrier="battery", **bus_sub_dict)
+    if "battery" in carriers:
+        b_buses_i = n.madd(
+            "Bus", buses_i + " battery", carrier="battery", **bus_sub_dict
+        )
 
-        n.madd("Store", b_buses_i,
-               bus=b_buses_i,
-               carrier='battery',
-               e_cyclic=True,
-               e_nom_extendable=True,
-               capital_cost=costs.at['battery storage', 'capital_cost'],
-               marginal_cost=costs.at["battery", "marginal_cost"])
+        n.madd(
+            "Store",
+            b_buses_i,
+            bus=b_buses_i,
+            carrier="battery",
+            e_cyclic=True,
+            e_nom_extendable=True,
+            capital_cost=costs.at["battery storage", "capital_cost"],
+            marginal_cost=costs.at["battery", "marginal_cost"],
+        )
 
-        n.madd("Link", b_buses_i + " charger",
-               bus0=buses_i,
-               bus1=b_buses_i,
-               carrier='battery charger',
-               efficiency=costs.at['battery inverter', 'efficiency'],
-               capital_cost=costs.at['battery inverter', 'capital_cost'],
-               p_nom_extendable=True,
-               marginal_cost=costs.at["battery inverter", "marginal_cost"])
+        n.madd(
+            "Link",
+            b_buses_i + " charger",
+            bus0=buses_i,
+            bus1=b_buses_i,
+            carrier="battery charger",
+            efficiency=costs.at["battery inverter", "efficiency"],
+            capital_cost=costs.at["battery inverter", "capital_cost"],
+            p_nom_extendable=True,
+            marginal_cost=costs.at["battery inverter", "marginal_cost"],
+        )
 
-        n.madd("Link", b_buses_i + " discharger",
-               bus0=b_buses_i,
-               bus1=buses_i,
-               carrier='battery discharger',
-               efficiency=costs.at['battery inverter', 'efficiency'],
-               p_nom_extendable=True,
-               marginal_cost=costs.at["battery inverter", "marginal_cost"])
+        n.madd(
+            "Link",
+            b_buses_i + " discharger",
+            bus0=b_buses_i,
+            bus1=buses_i,
+            carrier="battery discharger",
+            efficiency=costs.at["battery inverter", "efficiency"],
+            p_nom_extendable=True,
+            marginal_cost=costs.at["battery inverter", "marginal_cost"],
+        )
 
 
 def attach_hydrogen_pipelines(n, costs):
-    elec_opts = snakemake.config['electricity']
-    ext_carriers = elec_opts['extendable_carriers']
-    as_stores = ext_carriers.get('Store', [])
+    elec_opts = snakemake.config["electricity"]
+    ext_carriers = elec_opts["extendable_carriers"]
+    as_stores = ext_carriers.get("Store", [])
 
-    if 'H2 pipeline' not in ext_carriers.get('Link', []):
+    if "H2 pipeline" not in ext_carriers.get("Link", []):
         return
 
-    assert 'H2' in as_stores, ("Attaching hydrogen pipelines requires hydrogen "
-                               "storage to be modelled as Store-Link-Bus combination. See "
-                               "`config.yaml` at `electricity: extendable_carriers: Store:`.")
+    assert "H2" in as_stores, (
+        "Attaching hydrogen pipelines requires hydrogen "
+        "storage to be modelled as Store-Link-Bus combination. See "
+        "`config.yaml` at `electricity: extendable_carriers: Store:`."
+    )
 
     # determine bus pairs
     attrs = ["bus0", "bus1", "length"]
-    candidates = pd.concat([n.lines[attrs], n.links.query('carrier=="DC"')[attrs]])\
-        .reset_index(drop=True)
+    candidates = pd.concat(
+        [n.lines[attrs], n.links.query('carrier=="DC"')[attrs]]
+    ).reset_index(drop=True)
 
     # remove bus pair duplicates regardless of order of bus0 and bus1
-    h2_links = candidates[~pd.DataFrame(
-        np.sort(candidates[['bus0', 'bus1']])).duplicated()]
-    h2_links.index = h2_links.apply(
-        lambda c: f"H2 pipeline {c.bus0}-{c.bus1}", axis=1)
+    h2_links = candidates[
+        ~pd.DataFrame(np.sort(candidates[["bus0", "bus1"]])).duplicated()
+    ]
+    h2_links.index = h2_links.apply(lambda c: f"H2 pipeline {c.bus0}-{c.bus1}", axis=1)
 
     # add pipelines
-    n.madd("Link",
-           h2_links.index,
-           bus0=h2_links.bus0.values + " H2",
-           bus1=h2_links.bus1.values + " H2",
-           p_min_pu=-1,
-           p_nom_extendable=True,
-           length=h2_links.length.values,
-           capital_cost=costs.at['H2 pipeline',
-                                 'capital_cost']*h2_links.length,
-           efficiency=costs.at['H2 pipeline', 'efficiency'],
-           carrier="H2 pipeline")
+    n.madd(
+        "Link",
+        h2_links.index,
+        bus0=h2_links.bus0.values + " H2",
+        bus1=h2_links.bus1.values + " H2",
+        p_min_pu=-1,
+        p_nom_extendable=True,
+        length=h2_links.length.values,
+        capital_cost=costs.at["H2 pipeline", "capital_cost"] * h2_links.length,
+        efficiency=costs.at["H2 pipeline", "efficiency"],
+        carrier="H2 pipeline",
+    )
 
 
 if __name__ == "__main__":
-    if 'snakemake' not in globals():
+    if "snakemake" not in globals():
         from _helpers import mock_snakemake
+
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake('add_extra_components', network='elec',
-                                   simpl='', clusters=10)
+        snakemake = mock_snakemake(
+            "add_extra_components", network="elec", simpl="", clusters=10
+        )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    Nyears = n.snapshot_weightings.objective.sum() / 8760.
-    costs = load_costs(Nyears, tech_costs=snakemake.input.tech_costs,
-                       config=snakemake.config['costs'],
-                       elec_config=snakemake.config['electricity'])
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.0
+    costs = load_costs(
+        Nyears,
+        tech_costs=snakemake.input.tech_costs,
+        config=snakemake.config["costs"],
+        elec_config=snakemake.config["electricity"],
+    )
 
     attach_storageunits(n, costs)
     attach_stores(n, costs)

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -87,7 +87,8 @@ def attach_storageunits(n, costs):
             capital_cost=costs.at[carrier, "capital_cost"],
             marginal_cost=costs.at[carrier, "marginal_cost"],
             efficiency_store=costs.at[lookup_store[carrier], "efficiency"],
-            efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"],
+            efficiency_dispatch=costs.at[lookup_dispatch[carrier],
+                                         "efficiency"],
             max_hours=max_hours[carrier],
             cyclic_state_of_charge=True,
         )
@@ -103,7 +104,10 @@ def attach_stores(n, costs):
     bus_sub_dict = {k: n.buses[k].values for k in ["x", "y", "country"]}
 
     if "H2" in carriers:
-        h2_buses_i = n.madd("Bus", buses_i + " H2", carrier="H2", **bus_sub_dict)
+        h2_buses_i = n.madd("Bus",
+                            buses_i + " H2",
+                            carrier="H2",
+                            **bus_sub_dict)
 
         n.madd(
             "Store",
@@ -136,15 +140,16 @@ def attach_stores(n, costs):
             p_nom_extendable=True,
             efficiency=costs.at["fuel cell", "efficiency"],
             # NB: fixed cost is per MWel
-            capital_cost=costs.at["fuel cell", "capital_cost"]
-            * costs.at["fuel cell", "efficiency"],
+            capital_cost=costs.at["fuel cell", "capital_cost"] *
+            costs.at["fuel cell", "efficiency"],
             marginal_cost=costs.at["fuel cell", "marginal_cost"],
         )
 
     if "battery" in carriers:
-        b_buses_i = n.madd(
-            "Bus", buses_i + " battery", carrier="battery", **bus_sub_dict
-        )
+        b_buses_i = n.madd("Bus",
+                           buses_i + " battery",
+                           carrier="battery",
+                           **bus_sub_dict)
 
         n.madd(
             "Store",
@@ -192,20 +197,19 @@ def attach_hydrogen_pipelines(n, costs):
     assert "H2" in as_stores, (
         "Attaching hydrogen pipelines requires hydrogen "
         "storage to be modelled as Store-Link-Bus combination. See "
-        "`config.yaml` at `electricity: extendable_carriers: Store:`."
-    )
+        "`config.yaml` at `electricity: extendable_carriers: Store:`.")
 
     # determine bus pairs
     attrs = ["bus0", "bus1", "length"]
     candidates = pd.concat(
-        [n.lines[attrs], n.links.query('carrier=="DC"')[attrs]]
-    ).reset_index(drop=True)
+        [n.lines[attrs],
+         n.links.query('carrier=="DC"')[attrs]]).reset_index(drop=True)
 
     # remove bus pair duplicates regardless of order of bus0 and bus1
-    h2_links = candidates[
-        ~pd.DataFrame(np.sort(candidates[["bus0", "bus1"]])).duplicated()
-    ]
-    h2_links.index = h2_links.apply(lambda c: f"H2 pipeline {c.bus0}-{c.bus1}", axis=1)
+    h2_links = candidates[~pd.DataFrame(np.sort(candidates[["bus0", "bus1"]])).
+                          duplicated()]
+    h2_links.index = h2_links.apply(lambda c: f"H2 pipeline {c.bus0}-{c.bus1}",
+                                    axis=1)
 
     # add pipelines
     n.madd(
@@ -227,9 +231,10 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake(
-            "add_extra_components", network="elec", simpl="", clusters=10
-        )
+        snakemake = mock_snakemake("add_extra_components",
+                                   network="elec",
+                                   simpl="",
+                                   clusters=10)
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/add_extra_components.py
+++ b/scripts/add_extra_components.py
@@ -55,8 +55,9 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import (_add_missing_carriers_from_costs,
-                             add_nice_carrier_names, load_costs)
+from add_electricity import _add_missing_carriers_from_costs
+from add_electricity import add_nice_carrier_names
+from add_electricity import load_costs
 
 idx = pd.IndexSlice
 

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -122,7 +122,7 @@ def _find_closest_links(links, new_links, distance_upper_bound=1.5):
         dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
         index=new_links.index[found_i],
     ).sort_values(by="D")
-            [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
+        [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
 
 
 def _load_buses_from_osm():
@@ -145,7 +145,7 @@ def _load_buses_from_osm():
     # TODO Deprecated. No influence because of new rebase. Remove?
     buses_with_v_nom_to_keep_b = (buses.v_nom.isin(
         snakemake.config["electricity"]["voltages"])
-                                  | buses.v_nom.isnull())
+        | buses.v_nom.isnull())
     logger.info("Removing buses with voltages {}".format(
         pd.Index(buses.v_nom.unique()).dropna().difference(
             snakemake.config["electricity"]["voltages"])))

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -104,37 +104,39 @@ def _get_country(df):
 
 
 def _find_closest_links(links, new_links, distance_upper_bound=1.5):
-    treecoords = np.asarray([
-        np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten()
-        for s in links.geometry
-    ])
-    querycoords = np.vstack([
-        new_links[["x1", "y1", "x2", "y2"]],
-        new_links[["x2", "y2", "x1", "y1"]]
-    ])
+    treecoords = np.asarray(
+        [np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten() for s in links.geometry]
+    )
+    querycoords = np.vstack(
+        [new_links[["x1", "y1", "x2", "y2"]], new_links[["x2", "y2", "x1", "y1"]]]
+    )
     tree = sp.spatial.KDTree(treecoords)
-    dist, ind = tree.query(querycoords,
-                           distance_upper_bound=distance_upper_bound)
+    dist, ind = tree.query(querycoords, distance_upper_bound=distance_upper_bound)
     found_b = ind < len(links)
     found_i = np.arange(len(new_links) * 2)[found_b] % len(new_links)
 
-    return (pd.DataFrame(
-        dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
-        index=new_links.index[found_i],
-    ).sort_values(by="D")
-        [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
+    return (
+        pd.DataFrame(
+            dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
+            index=new_links.index[found_i],
+        )
+        .sort_values(by="D")[lambda ds: ~ds.index.duplicated(keep="first")]
+        .sort_index()["i"]
+    )
 
 
 def _load_buses_from_osm():
-    buses = (_read_csv_nafix(
-        snakemake.input.osm_buses).set_index("bus_id").drop(
-            ["station_id"], axis=1).rename(columns=dict(voltage="v_nom")))
+    buses = (
+        _read_csv_nafix(snakemake.input.osm_buses)
+        .set_index("bus_id")
+        .drop(["station_id"], axis=1)
+        .rename(columns=dict(voltage="v_nom"))
+    )
 
     buses = buses.loc[:, ~buses.columns.str.contains("^Unnamed")]
     buses["v_nom"] /= 1e3
     buses["carrier"] = buses.pop("dc").map({True: "DC", False: "AC"})
-    buses["under_construction"] = buses["under_construction"].fillna(
-        False).astype(bool)
+    buses["under_construction"] = buses["under_construction"].fillna(False).astype(bool)
     buses["x"] = buses["lon"]
     buses["y"] = buses["lat"]
     # TODO: Drop NAN maybe somewhere else?
@@ -143,12 +145,17 @@ def _load_buses_from_osm():
     buses = _rebase_voltage_to_config(buses)
 
     # TODO Deprecated. No influence because of new rebase. Remove?
-    buses_with_v_nom_to_keep_b = (buses.v_nom.isin(
-        snakemake.config["electricity"]["voltages"])
-        | buses.v_nom.isnull())
-    logger.info("Removing buses with voltages {}".format(
-        pd.Index(buses.v_nom.unique()).dropna().difference(
-            snakemake.config["electricity"]["voltages"])))
+    buses_with_v_nom_to_keep_b = (
+        buses.v_nom.isin(snakemake.config["electricity"]["voltages"])
+        | buses.v_nom.isnull()
+    )
+    logger.info(
+        "Removing buses with voltages {}".format(
+            pd.Index(buses.v_nom.unique())
+            .dropna()
+            .difference(snakemake.config["electricity"]["voltages"])
+        )
+    )
 
     return buses  # pd.DataFrame(buses.loc[buses_with_v_nom_to_keep_b])
     # return pd.DataFrame(buses.loc[buses_in_europe_b & buses_with_v_nom_to_keep_b])
@@ -190,10 +197,7 @@ def _load_links_from_eg(buses):
         quotechar="'",
         true_values="t",
         false_values="f",
-        dtype=dict(link_id="str",
-                   bus0="str",
-                   bus1="str",
-                   under_construction="bool"),
+        dtype=dict(link_id="str", bus0="str", bus1="str", under_construction="bool"),
     ).set_index("link_id")
 
     links["length"] /= 1e3
@@ -210,27 +214,30 @@ def _add_links_from_tyndp(buses, links):
     links_tyndp = _read_csv_nafix(snakemake.input.links_tyndp)
 
     # remove all links from list which lie outside all of the desired countries
-    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0,
-                                                                   "geometry"]
+    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0, "geometry"]
     europe_shape_prepped = shapely.prepared.prep(europe_shape)
     x1y1_in_europe_b = links_tyndp[["x1", "y1"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
+    )
     x2y2_in_europe_b = links_tyndp[["x2", "y2"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
+    )
     is_within_covered_countries_b = x1y1_in_europe_b & x2y2_in_europe_b
 
     if not is_within_covered_countries_b.all():
-        logger.info("TYNDP links outside of the covered area (skipping): " +
-                    ", ".join(links_tyndp.loc[~is_within_covered_countries_b,
-                                              "Name"]))
+        logger.info(
+            "TYNDP links outside of the covered area (skipping): "
+            + ", ".join(links_tyndp.loc[~is_within_covered_countries_b, "Name"])
+        )
         links_tyndp = links_tyndp.loc[is_within_covered_countries_b]
         if links_tyndp.empty:
             return buses, links
 
     has_replaces_b = links_tyndp.replaces.notnull()
     oids = dict(Bus=_get_oid(buses), Link=_get_oid(links))
-    keep_b = dict(Bus=pd.Series(True, index=buses.index),
-                  Link=pd.Series(True, index=links.index))
+    keep_b = dict(
+        Bus=pd.Series(True, index=buses.index), Link=pd.Series(True, index=links.index)
+    )
     for reps in links_tyndp.loc[has_replaces_b, "replaces"]:
         for comps in reps.split(":"):
             oids_to_remove = comps.split(".")
@@ -239,15 +246,16 @@ def _add_links_from_tyndp(buses, links):
     buses = buses.loc[keep_b["Bus"]]
     links = links.loc[keep_b["Link"]]
 
-    links_tyndp["j"] = _find_closest_links(links,
-                                           links_tyndp,
-                                           distance_upper_bound=0.20)
+    links_tyndp["j"] = _find_closest_links(
+        links, links_tyndp, distance_upper_bound=0.20
+    )
     # Corresponds approximately to 20km tolerances
 
     if links_tyndp["j"].notnull().any():
-        logger.info("TYNDP links already in the dataset (skipping): " +
-                    ",".join(links_tyndp.loc[links_tyndp["j"].notnull(),
-                                             "Name"]))
+        logger.info(
+            "TYNDP links already in the dataset (skipping): "
+            + ",".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"])
+        )
         links_tyndp = links_tyndp.loc[links_tyndp["j"].isnull()]
         if links_tyndp.empty:
             return buses, links
@@ -261,29 +269,42 @@ def _add_links_from_tyndp(buses, links):
     ind1_b = ind1 < len(buses)
     links_tyndp.loc[ind1_b, "bus1"] = buses.index[ind1[ind1_b]]
 
-    links_tyndp_located_b = (links_tyndp["bus0"].notnull()
-                             & links_tyndp["bus1"].notnull())
+    links_tyndp_located_b = (
+        links_tyndp["bus0"].notnull() & links_tyndp["bus1"].notnull()
+    )
     if not links_tyndp_located_b.all():
         logger.warning(
-            "Did not find connected buses for TYNDP links (skipping): " +
-            ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"]))
+            "Did not find connected buses for TYNDP links (skipping): "
+            + ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"])
+        )
         links_tyndp = links_tyndp.loc[links_tyndp_located_b]
 
-    logger.info("Adding the following TYNDP links: " +
-                ", ".join(links_tyndp["Name"]))
+    logger.info("Adding the following TYNDP links: " + ", ".join(links_tyndp["Name"]))
 
     links_tyndp = links_tyndp[["bus0", "bus1"]].assign(
         carrier="DC",
         p_nom=links_tyndp["Power (MW)"],
         length=links_tyndp["Length (given) (km)"].fillna(
-            links_tyndp["Length (distance*1.2) (km)"]),
+            links_tyndp["Length (distance*1.2) (km)"]
+        ),
         under_construction=True,
         underground=False,
-        geometry=(links_tyndp[["x1", "y1", "x2", "y2"]].apply(
-            lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1)),
-        tags=('"name"=>"' + links_tyndp["Name"] + '", ' + '"ref"=>"' +
-              links_tyndp["Ref"] + '", ' + '"status"=>"' +
-              links_tyndp["status"] + '"'),
+        geometry=(
+            links_tyndp[["x1", "y1", "x2", "y2"]].apply(
+                lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1
+            )
+        ),
+        tags=(
+            '"name"=>"'
+            + links_tyndp["Name"]
+            + '", '
+            + '"ref"=>"'
+            + links_tyndp["Ref"]
+            + '", '
+            + '"status"=>"'
+            + links_tyndp["status"]
+            + '"'
+        ),
     )
 
     links_tyndp.index = "T" + links_tyndp.index.astype(str)
@@ -292,22 +313,24 @@ def _add_links_from_tyndp(buses, links):
 
 
 def _load_lines_from_osm(buses):
-    lines = (_read_csv_nafix(
-        snakemake.input.osm_lines,
-        dtype=dict(
-            line_id="str",
-            bus0="str",
-            bus1="str",
-            underground="bool",
-            under_construction="bool",
-        ),
-    ).set_index("line_id").rename(
-        columns=dict(voltage="v_nom", circuits="num_parallel")))
+    lines = (
+        _read_csv_nafix(
+            snakemake.input.osm_lines,
+            dtype=dict(
+                line_id="str",
+                bus0="str",
+                bus1="str",
+                underground="bool",
+                under_construction="bool",
+            ),
+        )
+        .set_index("line_id")
+        .rename(columns=dict(voltage="v_nom", circuits="num_parallel"))
+    )
 
     lines["length"] /= 1e3  # m to km conversion
     lines["v_nom"] /= 1e3  # V to kV conversion
-    lines = lines.loc[:, ~lines.columns.str.contains(
-        "^Unnamed")]  # remove unnamed col
+    lines = lines.loc[:, ~lines.columns.str.contains("^Unnamed")]  # remove unnamed col
     lines = _rebase_voltage_to_config(lines)  # rebase voltage to config inputs
     # lines = _remove_dangling_branches(lines, buses)
 
@@ -353,8 +376,12 @@ def _set_electrical_parameters_lines(lines):
 
 def _set_lines_s_nom_from_linetypes(n):
     # n.line_types is a lineregister from pypsa/pandapowers
-    n.lines["s_nom"] = (np.sqrt(3) * n.lines["type"].map(n.line_types.i_nom) *
-                        n.lines["v_nom"] * n.lines.num_parallel)
+    n.lines["s_nom"] = (
+        np.sqrt(3)
+        * n.lines["type"].map(n.line_types.i_nom)
+        * n.lines["v_nom"]
+        * n.lines.num_parallel
+    )
 
 
 def _set_electrical_parameters_links(links):
@@ -368,21 +395,22 @@ def _set_electrical_parameters_links(links):
     links_p_nom = _read_csv_nafix(snakemake.input.links_p_nom)
 
     # filter links that are not in operation anymore
-    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced",
-                                                 na=False)
+    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced", na=False)
     links_p_nom = links_p_nom[~removed_b]
 
     # find closest link for all links in links_p_nom
     links_p_nom["j"] = _find_closest_links(links, links_p_nom)
 
-    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg(
-        {"Power (MW)": "sum"})
+    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg({"Power (MW)": "sum"})
 
     p_nom = links_p_nom.dropna(subset=["j"]).set_index("j")["Power (MW)"]
 
     # Don't update p_nom if it's already set
-    p_nom_unset = (p_nom.drop(links.index[links.p_nom.notnull()],
-                              errors="ignore") if "p_nom" in links else p_nom)
+    p_nom_unset = (
+        p_nom.drop(links.index[links.p_nom.notnull()], errors="ignore")
+        if "p_nom" in links
+        else p_nom
+    )
     links.loc[p_nom_unset.index, "p_nom"] = p_nom_unset
 
     return links
@@ -414,25 +442,25 @@ def _set_electrical_parameters_transformers(transformers):
 
 
 def _remove_dangling_branches(branches, buses):
-    return pd.DataFrame(branches.loc[branches.bus0.isin(buses.index)
-                                     & branches.bus1.isin(buses.index)])
+    return pd.DataFrame(
+        branches.loc[branches.bus0.isin(buses.index) & branches.bus1.isin(buses.index)]
+    )
 
 
 def _remove_unconnected_components(network):
-    _, labels = csgraph.connected_components(network.adjacency_matrix(),
-                                             directed=False)
+    _, labels = csgraph.connected_components(network.adjacency_matrix(), directed=False)
     component = pd.Series(labels, index=network.buses.index)
 
     component_sizes = component.value_counts()
     components_to_remove = component_sizes.iloc[1:]
 
     logger.info(
-        "Removing {} unconnected network components with less than {} buses. In total {} buses."
-        .format(
+        "Removing {} unconnected network components with less than {} buses. In total {} buses.".format(
             len(components_to_remove),
             components_to_remove.max(),
             components_to_remove.sum(),
-        ))
+        )
+    )
 
     return network[component == component_sizes.index[0]]
 
@@ -445,8 +473,10 @@ def _set_countries_and_substations(n):
         # shape = shapely.prepared.prep(shape)
         return pd.Series(
             np.fromiter(
-                (shape.contains(Point(x, y))
-                 for x, y in buses.loc[:, ["x", "y"]].values),
+                (
+                    shape.contains(Point(x, y))
+                    for x, y in buses.loc[:, ["x", "y"]].values
+                ),
                 dtype=bool,
                 count=len(buses),
             ),
@@ -454,16 +484,20 @@ def _set_countries_and_substations(n):
         )
 
     countries = create_country_list(snakemake.config["countries"])
-    country_shapes = (gpd.read_file(snakemake.input.country_shapes).set_index(
-        "name")["geometry"].set_crs(4326))
+    country_shapes = (
+        gpd.read_file(snakemake.input.country_shapes)
+        .set_index("name")["geometry"]
+        .set_crs(4326)
+    )
     offshore_shapes = unary_union(
-        gpd.read_file(
-            snakemake.input.offshore_shapes)["geometry"].set_crs(4326))
+        gpd.read_file(snakemake.input.offshore_shapes)["geometry"].set_crs(4326)
+    )
     # TODO: At the moment buses["symbol"] = False. This was set as default values
     # and need to be adjusted. What values should we put in?
     # .str.contains("substation|converter station",
-    substation_b = buses["symbol"].str.contains("substation|converter station",
-                                                case=False)
+    substation_b = buses["symbol"].str.contains(
+        "substation|converter station", case=False
+    )
 
     #                                             case=False)
 
@@ -471,14 +505,16 @@ def _set_countries_and_substations(n):
         index = x.index
         if len(index) == 1:
             return pd.Series(index, index)
-        key = (x.index[0] if x["v_nom"].isnull().all() else getattr(
-            x["v_nom"], "idx" + which)())
+        key = (
+            x.index[0]
+            if x["v_nom"].isnull().all()
+            else getattr(x["v_nom"], "idx" + which)()
+        )
         return pd.Series(key, index)
 
-    gb = buses.loc[substation_b].groupby(["x", "y"],
-                                         as_index=False,
-                                         group_keys=False,
-                                         sort=False)
+    gb = buses.loc[substation_b].groupby(
+        ["x", "y"], as_index=False, group_keys=False, sort=False
+    )
     # bus_map_low = gb.apply(prefer_voltage, "min")
     # lv_b = bus_map_low
     # TODO: implement missing
@@ -531,14 +567,13 @@ def _set_countries_and_substations(n):
         geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
         crs=4326,
     )
-    offshore_b = bus_locations.within(
-        offshore_shapes)  # Check if bus is in shape
+    offshore_b = bus_locations.within(offshore_shapes)  # Check if bus is in shape
 
     # Assumption that HV-bus qualifies as potential offshore bus. Offshore bus is empty otherwise.
     offshore_hvb = (
-        buses["v_nom"] >=
-        snakemake.config["base_network"]["min_voltage_substation_offshore"] /
-        1000)
+        buses["v_nom"]
+        >= snakemake.config["base_network"]["min_voltage_substation_offshore"] / 1000
+    )
     # Compares two lists & makes list value true if at least one is true
     buses["substation_off"] = offshore_b | offshore_hvb
 
@@ -560,22 +595,29 @@ def _set_countries_and_substations(n):
         n.transformers.drop("length", axis=1, inplace=True)
 
         for b in n.buses.index[c_tag_nan_b]:
-            df = (pd.DataFrame(
-                dict(pathlength=nx.single_source_dijkstra_path_length(
-                    graph, b, cutoff=200))).join(n.buses.country).dropna())
+            df = (
+                pd.DataFrame(
+                    dict(
+                        pathlength=nx.single_source_dijkstra_path_length(
+                            graph, b, cutoff=200
+                        )
+                    )
+                )
+                .join(n.buses.country)
+                .dropna()
+            )
             assert (
                 not df.empty
-            ), "No buses with defined country within 200km of bus `{}`".format(
-                b)
-            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(),
-                                              "country"]
+            ), "No buses with defined country within 200km of bus `{}`".format(b)
+            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(), "country"]
 
         logger.warning(
             "{} buses are not in any country or offshore shape,"
             " {} have been assigned from the tag of the entsoe map,"
             " the rest from the next bus in terms of pathlength.".format(
-                c_nan_b.sum(),
-                c_nan_b.sum() - c_tag_nan_b.sum()))
+                c_nan_b.sum(), c_nan_b.sum() - c_tag_nan_b.sum()
+            )
+        )
 
     return buses
 
@@ -584,8 +626,9 @@ def _replace_b2b_converter_at_country_border_by_link(n):
     # Affects only the B2B converter in Lithuania at the Polish border at the moment
     buscntry = n.buses.country
     linkcntry = n.links.bus0.map(buscntry)
-    converters_i = n.links.index[(n.links.carrier == "B2B")
-                                 & (linkcntry == n.links.bus1.map(buscntry))]
+    converters_i = n.links.index[
+        (n.links.carrier == "B2B") & (linkcntry == n.links.bus1.map(buscntry))
+    ]
 
     def findforeignbus(G, i):
         cntry = linkcntry.at[i]
@@ -603,13 +646,16 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             comp, line = next(iter(G[b0][b1]))
             if comp != "Line":
                 logger.warning(
-                    "Unable to replace B2B `{}` expected a Line, but found a {}"
-                    .format(i, comp))
+                    "Unable to replace B2B `{}` expected a Line, but found a {}".format(
+                        i, comp
+                    )
+                )
                 continue
 
             n.links.at[i, busattr] = b1
-            n.links.at[i, "p_nom"] = min(n.links.at[i, "p_nom"],
-                                         n.lines.at[line, "s_nom"])
+            n.links.at[i, "p_nom"] = min(
+                n.links.at[i, "p_nom"], n.lines.at[line, "s_nom"]
+            )
             n.links.at[i, "carrier"] = "DC"
             n.links.at[i, "underwater_fraction"] = 0.0
             n.links.at[i, "length"] = n.lines.at[line, "length"]
@@ -618,8 +664,10 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             n.remove("Bus", b0)
 
             logger.info(
-                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}"
-                .format(i, b0, line, linkcntry.at[i], buscntry.at[b1]))
+                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}".format(
+                    i, b0, line, linkcntry.at[i], buscntry.at[b1]
+                )
+            )
 
 
 def _set_links_underwater_fraction(n):
@@ -629,11 +677,11 @@ def _set_links_underwater_fraction(n):
     if not hasattr(n.links, "geometry"):
         n.links["underwater_fraction"] = 0.0
     else:
-        offshore_shape = gpd.read_file(
-            snakemake.input.offshore_shapes).unary_union
+        offshore_shape = gpd.read_file(snakemake.input.offshore_shapes).unary_union
         links = gpd.GeoSeries(n.links.geometry.dropna().map(shapely.wkt.loads))
         n.links["underwater_fraction"] = (
-            links.intersection(offshore_shape).length / links.length)
+            links.intersection(offshore_shape).length / links.length
+        )
 
 
 def _adjust_capacities_of_under_construction_branches(n):
@@ -678,17 +726,20 @@ def _rebase_voltage_to_config(component):
     ----------
     component : dataframe
     """
-    v_min = (snakemake.config["base_network"]["min_voltage_rebase_voltage"] /
-             1000)  # min. filtered value in dataset
+    v_min = (
+        snakemake.config["base_network"]["min_voltage_rebase_voltage"] / 1000
+    )  # min. filtered value in dataset
     v_low = snakemake.config["electricity"]["voltages"][0]
     v_mid = snakemake.config["electricity"]["voltages"][1]
     v_up = snakemake.config["electricity"]["voltages"][2]
     v_low_mid = (v_mid - v_low) / 2 + v_low  # between low and mid voltage
     v_mid_up = (v_up - v_mid) / 2 + v_mid  # between mid and upper voltage
-    component.loc[(v_min <= component["v_nom"]) &
-                  (component["v_nom"] < v_low_mid), "v_nom"] = v_low
-    component.loc[(v_low_mid <= component["v_nom"]) &
-                  (component["v_nom"] < v_mid_up), "v_nom"] = v_mid
+    component.loc[
+        (v_min <= component["v_nom"]) & (component["v_nom"] < v_low_mid), "v_nom"
+    ] = v_low
+    component.loc[
+        (v_low_mid <= component["v_nom"]) & (component["v_nom"] < v_mid_up), "v_nom"
+    ] = v_mid
     component.loc[v_mid_up <= component["v_nom"], "v_nom"] = v_up
 
     return component

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -104,37 +104,39 @@ def _get_country(df):
 
 
 def _find_closest_links(links, new_links, distance_upper_bound=1.5):
-    treecoords = np.asarray([
-        np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten()
-        for s in links.geometry
-    ])
-    querycoords = np.vstack([
-        new_links[["x1", "y1", "x2", "y2"]],
-        new_links[["x2", "y2", "x1", "y1"]]
-    ])
+    treecoords = np.asarray(
+        [np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten() for s in links.geometry]
+    )
+    querycoords = np.vstack(
+        [new_links[["x1", "y1", "x2", "y2"]], new_links[["x2", "y2", "x1", "y1"]]]
+    )
     tree = sp.spatial.KDTree(treecoords)
-    dist, ind = tree.query(querycoords,
-                           distance_upper_bound=distance_upper_bound)
+    dist, ind = tree.query(querycoords, distance_upper_bound=distance_upper_bound)
     found_b = ind < len(links)
     found_i = np.arange(len(new_links) * 2)[found_b] % len(new_links)
 
-    return (pd.DataFrame(
-        dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
-        index=new_links.index[found_i],
-    ).sort_values(by="D")
-        [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
+    return (
+        pd.DataFrame(
+            dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
+            index=new_links.index[found_i],
+        )
+        .sort_values(by="D")[lambda ds: ~ds.index.duplicated(keep="first")]
+        .sort_index()["i"]
+    )
 
 
 def _load_buses_from_osm():
-    buses = (_read_csv_nafix(
-        snakemake.input.osm_buses).set_index("bus_id").drop(
-            ["station_id"], axis=1).rename(columns=dict(voltage="v_nom")))
+    buses = (
+        _read_csv_nafix(snakemake.input.osm_buses)
+        .set_index("bus_id")
+        .drop(["station_id"], axis=1)
+        .rename(columns=dict(voltage="v_nom"))
+    )
 
     buses = buses.loc[:, ~buses.columns.str.contains("^Unnamed")]
     buses["v_nom"] /= 1e3
     buses["carrier"] = buses.pop("dc").map({True: "DC", False: "AC"})
-    buses["under_construction"] = buses["under_construction"].fillna(
-        False).astype(bool)
+    buses["under_construction"] = buses["under_construction"].fillna(False).astype(bool)
     buses["x"] = buses["lon"]
     buses["y"] = buses["lat"]
     # TODO: Drop NAN maybe somewhere else?
@@ -143,12 +145,17 @@ def _load_buses_from_osm():
     buses = _rebase_voltage_to_config(buses)
 
     # TODO Deprecated. No influence because of new rebase. Remove?
-    buses_with_v_nom_to_keep_b = (buses.v_nom.isin(
-        snakemake.config["electricity"]["voltages"])
-        | buses.v_nom.isnull())
-    logger.info("Removing buses with voltages {}".format(
-        pd.Index(buses.v_nom.unique()).dropna().difference(
-            snakemake.config["electricity"]["voltages"])))
+    buses_with_v_nom_to_keep_b = (
+        buses.v_nom.isin(snakemake.config["electricity"]["voltages"])
+        | buses.v_nom.isnull()
+    )
+    logger.info(
+        "Removing buses with voltages {}".format(
+            pd.Index(buses.v_nom.unique())
+            .dropna()
+            .difference(snakemake.config["electricity"]["voltages"])
+        )
+    )
 
     return buses  # pd.DataFrame(buses.loc[buses_with_v_nom_to_keep_b])
     # return pd.DataFrame(buses.loc[buses_in_europe_b & buses_with_v_nom_to_keep_b])
@@ -190,10 +197,7 @@ def _load_links_from_eg(buses):
         quotechar="'",
         true_values="t",
         false_values="f",
-        dtype=dict(link_id="str",
-                   bus0="str",
-                   bus1="str",
-                   under_construction="bool"),
+        dtype=dict(link_id="str", bus0="str", bus1="str", under_construction="bool"),
     ).set_index("link_id")
 
     links["length"] /= 1e3
@@ -210,27 +214,30 @@ def _add_links_from_tyndp(buses, links):
     links_tyndp = _read_csv_nafix(snakemake.input.links_tyndp)
 
     # remove all links from list which lie outside all of the desired countries
-    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0,
-                                                                   "geometry"]
+    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0, "geometry"]
     europe_shape_prepped = shapely.prepared.prep(europe_shape)
     x1y1_in_europe_b = links_tyndp[["x1", "y1"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
+    )
     x2y2_in_europe_b = links_tyndp[["x2", "y2"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
+    )
     is_within_covered_countries_b = x1y1_in_europe_b & x2y2_in_europe_b
 
     if not is_within_covered_countries_b.all():
-        logger.info("TYNDP links outside of the covered area (skipping): " +
-                    ", ".join(links_tyndp.loc[~is_within_covered_countries_b,
-                                              "Name"]))
+        logger.info(
+            "TYNDP links outside of the covered area (skipping): "
+            + ", ".join(links_tyndp.loc[~is_within_covered_countries_b, "Name"])
+        )
         links_tyndp = links_tyndp.loc[is_within_covered_countries_b]
         if links_tyndp.empty:
             return buses, links
 
     has_replaces_b = links_tyndp.replaces.notnull()
     oids = dict(Bus=_get_oid(buses), Link=_get_oid(links))
-    keep_b = dict(Bus=pd.Series(True, index=buses.index),
-                  Link=pd.Series(True, index=links.index))
+    keep_b = dict(
+        Bus=pd.Series(True, index=buses.index), Link=pd.Series(True, index=links.index)
+    )
     for reps in links_tyndp.loc[has_replaces_b, "replaces"]:
         for comps in reps.split(":"):
             oids_to_remove = comps.split(".")
@@ -239,15 +246,16 @@ def _add_links_from_tyndp(buses, links):
     buses = buses.loc[keep_b["Bus"]]
     links = links.loc[keep_b["Link"]]
 
-    links_tyndp["j"] = _find_closest_links(links,
-                                           links_tyndp,
-                                           distance_upper_bound=0.20)
+    links_tyndp["j"] = _find_closest_links(
+        links, links_tyndp, distance_upper_bound=0.20
+    )
     # Corresponds approximately to 20km tolerances
 
     if links_tyndp["j"].notnull().any():
-        logger.info("TYNDP links already in the dataset (skipping): " +
-                    ",".join(links_tyndp.loc[links_tyndp["j"].notnull(),
-                                             "Name"]))
+        logger.info(
+            "TYNDP links already in the dataset (skipping): "
+            + ",".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"])
+        )
         links_tyndp = links_tyndp.loc[links_tyndp["j"].isnull()]
         if links_tyndp.empty:
             return buses, links
@@ -261,29 +269,42 @@ def _add_links_from_tyndp(buses, links):
     ind1_b = ind1 < len(buses)
     links_tyndp.loc[ind1_b, "bus1"] = buses.index[ind1[ind1_b]]
 
-    links_tyndp_located_b = (links_tyndp["bus0"].notnull()
-                             & links_tyndp["bus1"].notnull())
+    links_tyndp_located_b = (
+        links_tyndp["bus0"].notnull() & links_tyndp["bus1"].notnull()
+    )
     if not links_tyndp_located_b.all():
         logger.warning(
-            "Did not find connected buses for TYNDP links (skipping): " +
-            ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"]))
+            "Did not find connected buses for TYNDP links (skipping): "
+            + ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"])
+        )
         links_tyndp = links_tyndp.loc[links_tyndp_located_b]
 
-    logger.info("Adding the following TYNDP links: " +
-                ", ".join(links_tyndp["Name"]))
+    logger.info("Adding the following TYNDP links: " + ", ".join(links_tyndp["Name"]))
 
     links_tyndp = links_tyndp[["bus0", "bus1"]].assign(
         carrier="DC",
         p_nom=links_tyndp["Power (MW)"],
         length=links_tyndp["Length (given) (km)"].fillna(
-            links_tyndp["Length (distance*1.2) (km)"]),
+            links_tyndp["Length (distance*1.2) (km)"]
+        ),
         under_construction=True,
         underground=False,
-        geometry=(links_tyndp[["x1", "y1", "x2", "y2"]].apply(
-            lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1)),
-        tags=('"name"=>"' + links_tyndp["Name"] + '", ' + '"ref"=>"' +
-              links_tyndp["Ref"] + '", ' + '"status"=>"' +
-              links_tyndp["status"] + '"'),
+        geometry=(
+            links_tyndp[["x1", "y1", "x2", "y2"]].apply(
+                lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1
+            )
+        ),
+        tags=(
+            '"name"=>"'
+            + links_tyndp["Name"]
+            + '", '
+            + '"ref"=>"'
+            + links_tyndp["Ref"]
+            + '", '
+            + '"status"=>"'
+            + links_tyndp["status"]
+            + '"'
+        ),
     )
 
     links_tyndp.index = "T" + links_tyndp.index.astype(str)
@@ -292,22 +313,24 @@ def _add_links_from_tyndp(buses, links):
 
 
 def _load_lines_from_osm(buses):
-    lines = (_read_csv_nafix(
-        snakemake.input.osm_lines,
-        dtype=dict(
-            line_id="str",
-            bus0="str",
-            bus1="str",
-            underground="bool",
-            under_construction="bool",
-        ),
-    ).set_index("line_id").rename(
-        columns=dict(voltage="v_nom", circuits="num_parallel")))
+    lines = (
+        _read_csv_nafix(
+            snakemake.input.osm_lines,
+            dtype=dict(
+                line_id="str",
+                bus0="str",
+                bus1="str",
+                underground="bool",
+                under_construction="bool",
+            ),
+        )
+        .set_index("line_id")
+        .rename(columns=dict(voltage="v_nom", circuits="num_parallel"))
+    )
 
     lines["length"] /= 1e3  # m to km conversion
     lines["v_nom"] /= 1e3  # V to kV conversion
-    lines = lines.loc[:, ~lines.columns.str.contains(
-        "^Unnamed")]  # remove unnamed col
+    lines = lines.loc[:, ~lines.columns.str.contains("^Unnamed")]  # remove unnamed col
     lines = _rebase_voltage_to_config(lines)  # rebase voltage to config inputs
     # lines = _remove_dangling_branches(lines, buses)
 
@@ -353,8 +376,12 @@ def _set_electrical_parameters_lines(lines):
 
 def _set_lines_s_nom_from_linetypes(n):
     # n.line_types is a lineregister from pypsa/pandapowers
-    n.lines["s_nom"] = (np.sqrt(3) * n.lines["type"].map(n.line_types.i_nom) *
-                        n.lines["v_nom"] * n.lines.num_parallel)
+    n.lines["s_nom"] = (
+        np.sqrt(3)
+        * n.lines["type"].map(n.line_types.i_nom)
+        * n.lines["v_nom"]
+        * n.lines.num_parallel
+    )
 
 
 def _set_electrical_parameters_links(links):
@@ -368,21 +395,22 @@ def _set_electrical_parameters_links(links):
     links_p_nom = _read_csv_nafix(snakemake.input.links_p_nom)
 
     # filter links that are not in operation anymore
-    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced",
-                                                 na=False)
+    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced", na=False)
     links_p_nom = links_p_nom[~removed_b]
 
     # find closest link for all links in links_p_nom
     links_p_nom["j"] = _find_closest_links(links, links_p_nom)
 
-    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg(
-        {"Power (MW)": "sum"})
+    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg({"Power (MW)": "sum"})
 
     p_nom = links_p_nom.dropna(subset=["j"]).set_index("j")["Power (MW)"]
 
     # Don't update p_nom if it's already set
-    p_nom_unset = (p_nom.drop(links.index[links.p_nom.notnull()],
-                              errors="ignore") if "p_nom" in links else p_nom)
+    p_nom_unset = (
+        p_nom.drop(links.index[links.p_nom.notnull()], errors="ignore")
+        if "p_nom" in links
+        else p_nom
+    )
     links.loc[p_nom_unset.index, "p_nom"] = p_nom_unset
 
     return links
@@ -414,25 +442,25 @@ def _set_electrical_parameters_transformers(transformers):
 
 
 def _remove_dangling_branches(branches, buses):
-    return pd.DataFrame(branches.loc[branches.bus0.isin(buses.index)
-                                     & branches.bus1.isin(buses.index)])
+    return pd.DataFrame(
+        branches.loc[branches.bus0.isin(buses.index) & branches.bus1.isin(buses.index)]
+    )
 
 
 def _remove_unconnected_components(network):
-    _, labels = csgraph.connected_components(network.adjacency_matrix(),
-                                             directed=False)
+    _, labels = csgraph.connected_components(network.adjacency_matrix(), directed=False)
     component = pd.Series(labels, index=network.buses.index)
 
     component_sizes = component.value_counts()
     components_to_remove = component_sizes.iloc[1:]
 
     logger.info(
-        "Removing {} unconnected network components with less than {} buses. In total {} buses."
-        .format(
+        "Removing {} unconnected network components with less than {} buses. In total {} buses.".format(
             len(components_to_remove),
             components_to_remove.max(),
             components_to_remove.sum(),
-        ))
+        )
+    )
 
     return network[component == component_sizes.index[0]]
 
@@ -445,8 +473,10 @@ def _set_countries_and_substations(n):
         # shape = shapely.prepared.prep(shape)
         return pd.Series(
             np.fromiter(
-                (shape.contains(Point(x, y))
-                 for x, y in buses.loc[:, ["x", "y"]].values),
+                (
+                    shape.contains(Point(x, y))
+                    for x, y in buses.loc[:, ["x", "y"]].values
+                ),
                 dtype=bool,
                 count=len(buses),
             ),
@@ -454,16 +484,20 @@ def _set_countries_and_substations(n):
         )
 
     countries = create_country_list(snakemake.config["countries"])
-    country_shapes = (gpd.read_file(snakemake.input.country_shapes).set_index(
-        "name")["geometry"].set_crs(4326))
-    offshore_shapes = unary_union(gpd.read_file(
-        snakemake.input.offshore_shapes)["geometry"].set_crs(
-            4326))
+    country_shapes = (
+        gpd.read_file(snakemake.input.country_shapes)
+        .set_index("name")["geometry"]
+        .set_crs(4326)
+    )
+    offshore_shapes = unary_union(
+        gpd.read_file(snakemake.input.offshore_shapes)["geometry"].set_crs(4326)
+    )
     # TODO: At the moment buses["symbol"] = False. This was set as default values
     # and need to be adjusted. What values should we put in?
     # .str.contains("substation|converter station",
     substation_b = buses["symbol"].str.contains(
-        "substation|converter station", case=False)
+        "substation|converter station", case=False
+    )
 
     #                                             case=False)
 
@@ -471,14 +505,16 @@ def _set_countries_and_substations(n):
         index = x.index
         if len(index) == 1:
             return pd.Series(index, index)
-        key = (x.index[0] if x["v_nom"].isnull().all() else getattr(
-            x["v_nom"], "idx" + which)())
+        key = (
+            x.index[0]
+            if x["v_nom"].isnull().all()
+            else getattr(x["v_nom"], "idx" + which)()
+        )
         return pd.Series(key, index)
 
-    gb = buses.loc[substation_b].groupby(["x", "y"],
-                                         as_index=False,
-                                         group_keys=False,
-                                         sort=False)
+    gb = buses.loc[substation_b].groupby(
+        ["x", "y"], as_index=False, group_keys=False, sort=False
+    )
     # bus_map_low = gb.apply(prefer_voltage, "min")
     # lv_b = bus_map_low
     # TODO: implement missing
@@ -526,18 +562,18 @@ def _set_countries_and_substations(n):
     # buses["substation_lv"] = True # TODO:remove as done in osm_build_network?
     # TODO: New implementation below
     bus_locations = buses
-    bus_locations = gpd.GeoDataFrame(bus_locations,
-                                     geometry=gpd.points_from_xy(
-                                         bus_locations.x, bus_locations.y),
-                                     crs=4326)
-    offshore_b = bus_locations.within(
-        offshore_shapes)  # Check if bus is in shape
+    bus_locations = gpd.GeoDataFrame(
+        bus_locations,
+        geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
+        crs=4326,
+    )
+    offshore_b = bus_locations.within(offshore_shapes)  # Check if bus is in shape
 
     # Assumption that HV-bus qualifies as potential offshore bus. Offshore bus is empty otherwise.
     offshore_hvb = (
-        buses["v_nom"] >=
-        snakemake.config["base_network"]["min_voltage_substation_offshore"] /
-        1000)
+        buses["v_nom"]
+        >= snakemake.config["base_network"]["min_voltage_substation_offshore"] / 1000
+    )
     # Compares two lists & makes list value true if at least one is true
     buses["substation_off"] = offshore_b | offshore_hvb
 
@@ -559,22 +595,29 @@ def _set_countries_and_substations(n):
         n.transformers.drop("length", axis=1, inplace=True)
 
         for b in n.buses.index[c_tag_nan_b]:
-            df = (pd.DataFrame(
-                dict(pathlength=nx.single_source_dijkstra_path_length(
-                    graph, b, cutoff=200))).join(n.buses.country).dropna())
+            df = (
+                pd.DataFrame(
+                    dict(
+                        pathlength=nx.single_source_dijkstra_path_length(
+                            graph, b, cutoff=200
+                        )
+                    )
+                )
+                .join(n.buses.country)
+                .dropna()
+            )
             assert (
                 not df.empty
-            ), "No buses with defined country within 200km of bus `{}`".format(
-                b)
-            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(),
-                                              "country"]
+            ), "No buses with defined country within 200km of bus `{}`".format(b)
+            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(), "country"]
 
         logger.warning(
             "{} buses are not in any country or offshore shape,"
             " {} have been assigned from the tag of the entsoe map,"
             " the rest from the next bus in terms of pathlength.".format(
-                c_nan_b.sum(),
-                c_nan_b.sum() - c_tag_nan_b.sum()))
+                c_nan_b.sum(), c_nan_b.sum() - c_tag_nan_b.sum()
+            )
+        )
 
     return buses
 
@@ -583,8 +626,9 @@ def _replace_b2b_converter_at_country_border_by_link(n):
     # Affects only the B2B converter in Lithuania at the Polish border at the moment
     buscntry = n.buses.country
     linkcntry = n.links.bus0.map(buscntry)
-    converters_i = n.links.index[(n.links.carrier == "B2B")
-                                 & (linkcntry == n.links.bus1.map(buscntry))]
+    converters_i = n.links.index[
+        (n.links.carrier == "B2B") & (linkcntry == n.links.bus1.map(buscntry))
+    ]
 
     def findforeignbus(G, i):
         cntry = linkcntry.at[i]
@@ -602,13 +646,16 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             comp, line = next(iter(G[b0][b1]))
             if comp != "Line":
                 logger.warning(
-                    "Unable to replace B2B `{}` expected a Line, but found a {}"
-                    .format(i, comp))
+                    "Unable to replace B2B `{}` expected a Line, but found a {}".format(
+                        i, comp
+                    )
+                )
                 continue
 
             n.links.at[i, busattr] = b1
-            n.links.at[i, "p_nom"] = min(n.links.at[i, "p_nom"],
-                                         n.lines.at[line, "s_nom"])
+            n.links.at[i, "p_nom"] = min(
+                n.links.at[i, "p_nom"], n.lines.at[line, "s_nom"]
+            )
             n.links.at[i, "carrier"] = "DC"
             n.links.at[i, "underwater_fraction"] = 0.0
             n.links.at[i, "length"] = n.lines.at[line, "length"]
@@ -617,8 +664,10 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             n.remove("Bus", b0)
 
             logger.info(
-                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}"
-                .format(i, b0, line, linkcntry.at[i], buscntry.at[b1]))
+                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}".format(
+                    i, b0, line, linkcntry.at[i], buscntry.at[b1]
+                )
+            )
 
 
 def _set_links_underwater_fraction(n):
@@ -628,11 +677,11 @@ def _set_links_underwater_fraction(n):
     if not hasattr(n.links, "geometry"):
         n.links["underwater_fraction"] = 0.0
     else:
-        offshore_shape = gpd.read_file(
-            snakemake.input.offshore_shapes).unary_union
+        offshore_shape = gpd.read_file(snakemake.input.offshore_shapes).unary_union
         links = gpd.GeoSeries(n.links.geometry.dropna().map(shapely.wkt.loads))
         n.links["underwater_fraction"] = (
-            links.intersection(offshore_shape).length / links.length)
+            links.intersection(offshore_shape).length / links.length
+        )
 
 
 def _adjust_capacities_of_under_construction_branches(n):
@@ -677,17 +726,20 @@ def _rebase_voltage_to_config(component):
     ----------
     component : dataframe
     """
-    v_min = (snakemake.config["base_network"]["min_voltage_rebase_voltage"] /
-             1000)  # min. filtered value in dataset
+    v_min = (
+        snakemake.config["base_network"]["min_voltage_rebase_voltage"] / 1000
+    )  # min. filtered value in dataset
     v_low = snakemake.config["electricity"]["voltages"][0]
     v_mid = snakemake.config["electricity"]["voltages"][1]
     v_up = snakemake.config["electricity"]["voltages"][2]
     v_low_mid = (v_mid - v_low) / 2 + v_low  # between low and mid voltage
     v_mid_up = (v_up - v_mid) / 2 + v_mid  # between mid and upper voltage
-    component.loc[(v_min <= component["v_nom"]) &
-                  (component["v_nom"] < v_low_mid), "v_nom"] = v_low
-    component.loc[(v_low_mid <= component["v_nom"]) &
-                  (component["v_nom"] < v_mid_up), "v_nom"] = v_mid
+    component.loc[
+        (v_min <= component["v_nom"]) & (component["v_nom"] < v_low_mid), "v_nom"
+    ] = v_low
+    component.loc[
+        (v_low_mid <= component["v_nom"]) & (component["v_nom"] < v_mid_up), "v_nom"
+    ] = v_mid
     component.loc[v_mid_up <= component["v_nom"], "v_nom"] = v_up
 
     return component

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -104,39 +104,37 @@ def _get_country(df):
 
 
 def _find_closest_links(links, new_links, distance_upper_bound=1.5):
-    treecoords = np.asarray(
-        [np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten() for s in links.geometry]
-    )
-    querycoords = np.vstack(
-        [new_links[["x1", "y1", "x2", "y2"]], new_links[["x2", "y2", "x1", "y1"]]]
-    )
+    treecoords = np.asarray([
+        np.asarray(shapely.wkt.loads(s))[[0, -1]].flatten()
+        for s in links.geometry
+    ])
+    querycoords = np.vstack([
+        new_links[["x1", "y1", "x2", "y2"]],
+        new_links[["x2", "y2", "x1", "y1"]]
+    ])
     tree = sp.spatial.KDTree(treecoords)
-    dist, ind = tree.query(querycoords, distance_upper_bound=distance_upper_bound)
+    dist, ind = tree.query(querycoords,
+                           distance_upper_bound=distance_upper_bound)
     found_b = ind < len(links)
     found_i = np.arange(len(new_links) * 2)[found_b] % len(new_links)
 
-    return (
-        pd.DataFrame(
-            dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
-            index=new_links.index[found_i],
-        )
-        .sort_values(by="D")[lambda ds: ~ds.index.duplicated(keep="first")]
-        .sort_index()["i"]
-    )
+    return (pd.DataFrame(
+        dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
+        index=new_links.index[found_i],
+    ).sort_values(by="D")
+            [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
 
 
 def _load_buses_from_osm():
-    buses = (
-        _read_csv_nafix(snakemake.input.osm_buses)
-        .set_index("bus_id")
-        .drop(["station_id"], axis=1)
-        .rename(columns=dict(voltage="v_nom"))
-    )
+    buses = (_read_csv_nafix(
+        snakemake.input.osm_buses).set_index("bus_id").drop(
+            ["station_id"], axis=1).rename(columns=dict(voltage="v_nom")))
 
     buses = buses.loc[:, ~buses.columns.str.contains("^Unnamed")]
     buses["v_nom"] /= 1e3
     buses["carrier"] = buses.pop("dc").map({True: "DC", False: "AC"})
-    buses["under_construction"] = buses["under_construction"].fillna(False).astype(bool)
+    buses["under_construction"] = buses["under_construction"].fillna(
+        False).astype(bool)
     buses["x"] = buses["lon"]
     buses["y"] = buses["lat"]
     # TODO: Drop NAN maybe somewhere else?
@@ -145,17 +143,12 @@ def _load_buses_from_osm():
     buses = _rebase_voltage_to_config(buses)
 
     # TODO Deprecated. No influence because of new rebase. Remove?
-    buses_with_v_nom_to_keep_b = (
-        buses.v_nom.isin(snakemake.config["electricity"]["voltages"])
-        | buses.v_nom.isnull()
-    )
-    logger.info(
-        "Removing buses with voltages {}".format(
-            pd.Index(buses.v_nom.unique())
-            .dropna()
-            .difference(snakemake.config["electricity"]["voltages"])
-        )
-    )
+    buses_with_v_nom_to_keep_b = (buses.v_nom.isin(
+        snakemake.config["electricity"]["voltages"])
+                                  | buses.v_nom.isnull())
+    logger.info("Removing buses with voltages {}".format(
+        pd.Index(buses.v_nom.unique()).dropna().difference(
+            snakemake.config["electricity"]["voltages"])))
 
     return buses  # pd.DataFrame(buses.loc[buses_with_v_nom_to_keep_b])
     # return pd.DataFrame(buses.loc[buses_in_europe_b & buses_with_v_nom_to_keep_b])
@@ -197,7 +190,10 @@ def _load_links_from_eg(buses):
         quotechar="'",
         true_values="t",
         false_values="f",
-        dtype=dict(link_id="str", bus0="str", bus1="str", under_construction="bool"),
+        dtype=dict(link_id="str",
+                   bus0="str",
+                   bus1="str",
+                   under_construction="bool"),
     ).set_index("link_id")
 
     links["length"] /= 1e3
@@ -214,30 +210,27 @@ def _add_links_from_tyndp(buses, links):
     links_tyndp = _read_csv_nafix(snakemake.input.links_tyndp)
 
     # remove all links from list which lie outside all of the desired countries
-    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0, "geometry"]
+    europe_shape = gpd.read_file(snakemake.input.europe_shape).loc[0,
+                                                                   "geometry"]
     europe_shape_prepped = shapely.prepared.prep(europe_shape)
     x1y1_in_europe_b = links_tyndp[["x1", "y1"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
-    )
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
     x2y2_in_europe_b = links_tyndp[["x2", "y2"]].apply(
-        lambda p: europe_shape_prepped.contains(Point(p)), axis=1
-    )
+        lambda p: europe_shape_prepped.contains(Point(p)), axis=1)
     is_within_covered_countries_b = x1y1_in_europe_b & x2y2_in_europe_b
 
     if not is_within_covered_countries_b.all():
-        logger.info(
-            "TYNDP links outside of the covered area (skipping): "
-            + ", ".join(links_tyndp.loc[~is_within_covered_countries_b, "Name"])
-        )
+        logger.info("TYNDP links outside of the covered area (skipping): " +
+                    ", ".join(links_tyndp.loc[~is_within_covered_countries_b,
+                                              "Name"]))
         links_tyndp = links_tyndp.loc[is_within_covered_countries_b]
         if links_tyndp.empty:
             return buses, links
 
     has_replaces_b = links_tyndp.replaces.notnull()
     oids = dict(Bus=_get_oid(buses), Link=_get_oid(links))
-    keep_b = dict(
-        Bus=pd.Series(True, index=buses.index), Link=pd.Series(True, index=links.index)
-    )
+    keep_b = dict(Bus=pd.Series(True, index=buses.index),
+                  Link=pd.Series(True, index=links.index))
     for reps in links_tyndp.loc[has_replaces_b, "replaces"]:
         for comps in reps.split(":"):
             oids_to_remove = comps.split(".")
@@ -246,16 +239,15 @@ def _add_links_from_tyndp(buses, links):
     buses = buses.loc[keep_b["Bus"]]
     links = links.loc[keep_b["Link"]]
 
-    links_tyndp["j"] = _find_closest_links(
-        links, links_tyndp, distance_upper_bound=0.20
-    )
+    links_tyndp["j"] = _find_closest_links(links,
+                                           links_tyndp,
+                                           distance_upper_bound=0.20)
     # Corresponds approximately to 20km tolerances
 
     if links_tyndp["j"].notnull().any():
-        logger.info(
-            "TYNDP links already in the dataset (skipping): "
-            + ",".join(links_tyndp.loc[links_tyndp["j"].notnull(), "Name"])
-        )
+        logger.info("TYNDP links already in the dataset (skipping): " +
+                    ",".join(links_tyndp.loc[links_tyndp["j"].notnull(),
+                                             "Name"]))
         links_tyndp = links_tyndp.loc[links_tyndp["j"].isnull()]
         if links_tyndp.empty:
             return buses, links
@@ -269,42 +261,29 @@ def _add_links_from_tyndp(buses, links):
     ind1_b = ind1 < len(buses)
     links_tyndp.loc[ind1_b, "bus1"] = buses.index[ind1[ind1_b]]
 
-    links_tyndp_located_b = (
-        links_tyndp["bus0"].notnull() & links_tyndp["bus1"].notnull()
-    )
+    links_tyndp_located_b = (links_tyndp["bus0"].notnull()
+                             & links_tyndp["bus1"].notnull())
     if not links_tyndp_located_b.all():
         logger.warning(
-            "Did not find connected buses for TYNDP links (skipping): "
-            + ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"])
-        )
+            "Did not find connected buses for TYNDP links (skipping): " +
+            ", ".join(links_tyndp.loc[~links_tyndp_located_b, "Name"]))
         links_tyndp = links_tyndp.loc[links_tyndp_located_b]
 
-    logger.info("Adding the following TYNDP links: " + ", ".join(links_tyndp["Name"]))
+    logger.info("Adding the following TYNDP links: " +
+                ", ".join(links_tyndp["Name"]))
 
     links_tyndp = links_tyndp[["bus0", "bus1"]].assign(
         carrier="DC",
         p_nom=links_tyndp["Power (MW)"],
         length=links_tyndp["Length (given) (km)"].fillna(
-            links_tyndp["Length (distance*1.2) (km)"]
-        ),
+            links_tyndp["Length (distance*1.2) (km)"]),
         under_construction=True,
         underground=False,
-        geometry=(
-            links_tyndp[["x1", "y1", "x2", "y2"]].apply(
-                lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1
-            )
-        ),
-        tags=(
-            '"name"=>"'
-            + links_tyndp["Name"]
-            + '", '
-            + '"ref"=>"'
-            + links_tyndp["Ref"]
-            + '", '
-            + '"status"=>"'
-            + links_tyndp["status"]
-            + '"'
-        ),
+        geometry=(links_tyndp[["x1", "y1", "x2", "y2"]].apply(
+            lambda s: str(LineString([[s.x1, s.y1], [s.x2, s.y2]])), axis=1)),
+        tags=('"name"=>"' + links_tyndp["Name"] + '", ' + '"ref"=>"' +
+              links_tyndp["Ref"] + '", ' + '"status"=>"' +
+              links_tyndp["status"] + '"'),
     )
 
     links_tyndp.index = "T" + links_tyndp.index.astype(str)
@@ -313,24 +292,22 @@ def _add_links_from_tyndp(buses, links):
 
 
 def _load_lines_from_osm(buses):
-    lines = (
-        _read_csv_nafix(
-            snakemake.input.osm_lines,
-            dtype=dict(
-                line_id="str",
-                bus0="str",
-                bus1="str",
-                underground="bool",
-                under_construction="bool",
-            ),
-        )
-        .set_index("line_id")
-        .rename(columns=dict(voltage="v_nom", circuits="num_parallel"))
-    )
+    lines = (_read_csv_nafix(
+        snakemake.input.osm_lines,
+        dtype=dict(
+            line_id="str",
+            bus0="str",
+            bus1="str",
+            underground="bool",
+            under_construction="bool",
+        ),
+    ).set_index("line_id").rename(
+        columns=dict(voltage="v_nom", circuits="num_parallel")))
 
     lines["length"] /= 1e3  # m to km conversion
     lines["v_nom"] /= 1e3  # V to kV conversion
-    lines = lines.loc[:, ~lines.columns.str.contains("^Unnamed")]  # remove unnamed col
+    lines = lines.loc[:, ~lines.columns.str.contains(
+        "^Unnamed")]  # remove unnamed col
     lines = _rebase_voltage_to_config(lines)  # rebase voltage to config inputs
     # lines = _remove_dangling_branches(lines, buses)
 
@@ -376,12 +353,8 @@ def _set_electrical_parameters_lines(lines):
 
 def _set_lines_s_nom_from_linetypes(n):
     # n.line_types is a lineregister from pypsa/pandapowers
-    n.lines["s_nom"] = (
-        np.sqrt(3)
-        * n.lines["type"].map(n.line_types.i_nom)
-        * n.lines["v_nom"]
-        * n.lines.num_parallel
-    )
+    n.lines["s_nom"] = (np.sqrt(3) * n.lines["type"].map(n.line_types.i_nom) *
+                        n.lines["v_nom"] * n.lines.num_parallel)
 
 
 def _set_electrical_parameters_links(links):
@@ -395,22 +368,21 @@ def _set_electrical_parameters_links(links):
     links_p_nom = _read_csv_nafix(snakemake.input.links_p_nom)
 
     # filter links that are not in operation anymore
-    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced", na=False)
+    removed_b = links_p_nom.Remarks.str.contains("Shut down|Replaced",
+                                                 na=False)
     links_p_nom = links_p_nom[~removed_b]
 
     # find closest link for all links in links_p_nom
     links_p_nom["j"] = _find_closest_links(links, links_p_nom)
 
-    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg({"Power (MW)": "sum"})
+    links_p_nom = links_p_nom.groupby(["j"], as_index=False).agg(
+        {"Power (MW)": "sum"})
 
     p_nom = links_p_nom.dropna(subset=["j"]).set_index("j")["Power (MW)"]
 
     # Don't update p_nom if it's already set
-    p_nom_unset = (
-        p_nom.drop(links.index[links.p_nom.notnull()], errors="ignore")
-        if "p_nom" in links
-        else p_nom
-    )
+    p_nom_unset = (p_nom.drop(links.index[links.p_nom.notnull()],
+                              errors="ignore") if "p_nom" in links else p_nom)
     links.loc[p_nom_unset.index, "p_nom"] = p_nom_unset
 
     return links
@@ -442,25 +414,25 @@ def _set_electrical_parameters_transformers(transformers):
 
 
 def _remove_dangling_branches(branches, buses):
-    return pd.DataFrame(
-        branches.loc[branches.bus0.isin(buses.index) & branches.bus1.isin(buses.index)]
-    )
+    return pd.DataFrame(branches.loc[branches.bus0.isin(buses.index)
+                                     & branches.bus1.isin(buses.index)])
 
 
 def _remove_unconnected_components(network):
-    _, labels = csgraph.connected_components(network.adjacency_matrix(), directed=False)
+    _, labels = csgraph.connected_components(network.adjacency_matrix(),
+                                             directed=False)
     component = pd.Series(labels, index=network.buses.index)
 
     component_sizes = component.value_counts()
     components_to_remove = component_sizes.iloc[1:]
 
     logger.info(
-        "Removing {} unconnected network components with less than {} buses. In total {} buses.".format(
+        "Removing {} unconnected network components with less than {} buses. In total {} buses."
+        .format(
             len(components_to_remove),
             components_to_remove.max(),
             components_to_remove.sum(),
-        )
-    )
+        ))
 
     return network[component == component_sizes.index[0]]
 
@@ -473,10 +445,8 @@ def _set_countries_and_substations(n):
         # shape = shapely.prepared.prep(shape)
         return pd.Series(
             np.fromiter(
-                (
-                    shape.contains(Point(x, y))
-                    for x, y in buses.loc[:, ["x", "y"]].values
-                ),
+                (shape.contains(Point(x, y))
+                 for x, y in buses.loc[:, ["x", "y"]].values),
                 dtype=bool,
                 count=len(buses),
             ),
@@ -484,20 +454,16 @@ def _set_countries_and_substations(n):
         )
 
     countries = create_country_list(snakemake.config["countries"])
-    country_shapes = (
-        gpd.read_file(snakemake.input.country_shapes)
-        .set_index("name")["geometry"]
-        .set_crs(4326)
-    )
+    country_shapes = (gpd.read_file(snakemake.input.country_shapes).set_index(
+        "name")["geometry"].set_crs(4326))
     offshore_shapes = unary_union(
-        gpd.read_file(snakemake.input.offshore_shapes)["geometry"].set_crs(4326)
-    )
+        gpd.read_file(
+            snakemake.input.offshore_shapes)["geometry"].set_crs(4326))
     # TODO: At the moment buses["symbol"] = False. This was set as default values
     # and need to be adjusted. What values should we put in?
     # .str.contains("substation|converter station",
-    substation_b = buses["symbol"].str.contains(
-        "substation|converter station", case=False
-    )
+    substation_b = buses["symbol"].str.contains("substation|converter station",
+                                                case=False)
 
     #                                             case=False)
 
@@ -505,16 +471,14 @@ def _set_countries_and_substations(n):
         index = x.index
         if len(index) == 1:
             return pd.Series(index, index)
-        key = (
-            x.index[0]
-            if x["v_nom"].isnull().all()
-            else getattr(x["v_nom"], "idx" + which)()
-        )
+        key = (x.index[0] if x["v_nom"].isnull().all() else getattr(
+            x["v_nom"], "idx" + which)())
         return pd.Series(key, index)
 
-    gb = buses.loc[substation_b].groupby(
-        ["x", "y"], as_index=False, group_keys=False, sort=False
-    )
+    gb = buses.loc[substation_b].groupby(["x", "y"],
+                                         as_index=False,
+                                         group_keys=False,
+                                         sort=False)
     # bus_map_low = gb.apply(prefer_voltage, "min")
     # lv_b = bus_map_low
     # TODO: implement missing
@@ -567,13 +531,14 @@ def _set_countries_and_substations(n):
         geometry=gpd.points_from_xy(bus_locations.x, bus_locations.y),
         crs=4326,
     )
-    offshore_b = bus_locations.within(offshore_shapes)  # Check if bus is in shape
+    offshore_b = bus_locations.within(
+        offshore_shapes)  # Check if bus is in shape
 
     # Assumption that HV-bus qualifies as potential offshore bus. Offshore bus is empty otherwise.
     offshore_hvb = (
-        buses["v_nom"]
-        >= snakemake.config["base_network"]["min_voltage_substation_offshore"] / 1000
-    )
+        buses["v_nom"] >=
+        snakemake.config["base_network"]["min_voltage_substation_offshore"] /
+        1000)
     # Compares two lists & makes list value true if at least one is true
     buses["substation_off"] = offshore_b | offshore_hvb
 
@@ -595,29 +560,22 @@ def _set_countries_and_substations(n):
         n.transformers.drop("length", axis=1, inplace=True)
 
         for b in n.buses.index[c_tag_nan_b]:
-            df = (
-                pd.DataFrame(
-                    dict(
-                        pathlength=nx.single_source_dijkstra_path_length(
-                            graph, b, cutoff=200
-                        )
-                    )
-                )
-                .join(n.buses.country)
-                .dropna()
-            )
+            df = (pd.DataFrame(
+                dict(pathlength=nx.single_source_dijkstra_path_length(
+                    graph, b, cutoff=200))).join(n.buses.country).dropna())
             assert (
                 not df.empty
-            ), "No buses with defined country within 200km of bus `{}`".format(b)
-            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(), "country"]
+            ), "No buses with defined country within 200km of bus `{}`".format(
+                b)
+            n.buses.at[b, "country"] = df.loc[df.pathlength.idxmin(),
+                                              "country"]
 
         logger.warning(
             "{} buses are not in any country or offshore shape,"
             " {} have been assigned from the tag of the entsoe map,"
             " the rest from the next bus in terms of pathlength.".format(
-                c_nan_b.sum(), c_nan_b.sum() - c_tag_nan_b.sum()
-            )
-        )
+                c_nan_b.sum(),
+                c_nan_b.sum() - c_tag_nan_b.sum()))
 
     return buses
 
@@ -626,9 +584,8 @@ def _replace_b2b_converter_at_country_border_by_link(n):
     # Affects only the B2B converter in Lithuania at the Polish border at the moment
     buscntry = n.buses.country
     linkcntry = n.links.bus0.map(buscntry)
-    converters_i = n.links.index[
-        (n.links.carrier == "B2B") & (linkcntry == n.links.bus1.map(buscntry))
-    ]
+    converters_i = n.links.index[(n.links.carrier == "B2B")
+                                 & (linkcntry == n.links.bus1.map(buscntry))]
 
     def findforeignbus(G, i):
         cntry = linkcntry.at[i]
@@ -646,16 +603,13 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             comp, line = next(iter(G[b0][b1]))
             if comp != "Line":
                 logger.warning(
-                    "Unable to replace B2B `{}` expected a Line, but found a {}".format(
-                        i, comp
-                    )
-                )
+                    "Unable to replace B2B `{}` expected a Line, but found a {}"
+                    .format(i, comp))
                 continue
 
             n.links.at[i, busattr] = b1
-            n.links.at[i, "p_nom"] = min(
-                n.links.at[i, "p_nom"], n.lines.at[line, "s_nom"]
-            )
+            n.links.at[i, "p_nom"] = min(n.links.at[i, "p_nom"],
+                                         n.lines.at[line, "s_nom"])
             n.links.at[i, "carrier"] = "DC"
             n.links.at[i, "underwater_fraction"] = 0.0
             n.links.at[i, "length"] = n.lines.at[line, "length"]
@@ -664,10 +618,8 @@ def _replace_b2b_converter_at_country_border_by_link(n):
             n.remove("Bus", b0)
 
             logger.info(
-                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}".format(
-                    i, b0, line, linkcntry.at[i], buscntry.at[b1]
-                )
-            )
+                "Replacing B2B converter `{}` together with bus `{}` and line `{}` by an HVDC tie-line {}-{}"
+                .format(i, b0, line, linkcntry.at[i], buscntry.at[b1]))
 
 
 def _set_links_underwater_fraction(n):
@@ -677,11 +629,11 @@ def _set_links_underwater_fraction(n):
     if not hasattr(n.links, "geometry"):
         n.links["underwater_fraction"] = 0.0
     else:
-        offshore_shape = gpd.read_file(snakemake.input.offshore_shapes).unary_union
+        offshore_shape = gpd.read_file(
+            snakemake.input.offshore_shapes).unary_union
         links = gpd.GeoSeries(n.links.geometry.dropna().map(shapely.wkt.loads))
         n.links["underwater_fraction"] = (
-            links.intersection(offshore_shape).length / links.length
-        )
+            links.intersection(offshore_shape).length / links.length)
 
 
 def _adjust_capacities_of_under_construction_branches(n):
@@ -726,20 +678,17 @@ def _rebase_voltage_to_config(component):
     ----------
     component : dataframe
     """
-    v_min = (
-        snakemake.config["base_network"]["min_voltage_rebase_voltage"] / 1000
-    )  # min. filtered value in dataset
+    v_min = (snakemake.config["base_network"]["min_voltage_rebase_voltage"] /
+             1000)  # min. filtered value in dataset
     v_low = snakemake.config["electricity"]["voltages"][0]
     v_mid = snakemake.config["electricity"]["voltages"][1]
     v_up = snakemake.config["electricity"]["voltages"][2]
     v_low_mid = (v_mid - v_low) / 2 + v_low  # between low and mid voltage
     v_mid_up = (v_up - v_mid) / 2 + v_mid  # between mid and upper voltage
-    component.loc[
-        (v_min <= component["v_nom"]) & (component["v_nom"] < v_low_mid), "v_nom"
-    ] = v_low
-    component.loc[
-        (v_low_mid <= component["v_nom"]) & (component["v_nom"] < v_mid_up), "v_nom"
-    ] = v_mid
+    component.loc[(v_min <= component["v_nom"]) &
+                  (component["v_nom"] < v_low_mid), "v_nom"] = v_low
+    component.loc[(v_low_mid <= component["v_nom"]) &
+                  (component["v_nom"] < v_mid_up), "v_nom"] = v_mid
     component.loc[v_mid_up <= component["v_nom"], "v_nom"] = v_up
 
     return component

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -75,10 +75,12 @@ import scipy as sp
 import shapely.prepared
 import shapely.wkt
 import yaml
-from _helpers import _read_csv_nafix, configure_logging
+from _helpers import _read_csv_nafix
+from _helpers import configure_logging
 from osm_pbf_power_data_extractor import create_country_list
 from scipy.sparse import csgraph
-from shapely.geometry import LineString, Point
+from shapely.geometry import LineString
+from shapely.geometry import Point
 from shapely.ops import unary_union
 
 logger = logging.getLogger(__name__)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -122,7 +122,7 @@ def _find_closest_links(links, new_links, distance_upper_bound=1.5):
         dict(D=dist[found_b], i=links.index[ind[found_b] % len(links)]),
         index=new_links.index[found_i],
     ).sort_values(by="D")
-            [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
+        [lambda ds: ~ds.index.duplicated(keep="first")].sort_index()["i"])
 
 
 def _load_buses_from_osm():
@@ -145,7 +145,7 @@ def _load_buses_from_osm():
     # TODO Deprecated. No influence because of new rebase. Remove?
     buses_with_v_nom_to_keep_b = (buses.v_nom.isin(
         snakemake.config["electricity"]["voltages"])
-                                  | buses.v_nom.isnull())
+        | buses.v_nom.isnull())
     logger.info("Removing buses with voltages {}".format(
         pd.Index(buses.v_nom.unique()).dropna().difference(
             snakemake.config["electricity"]["voltages"])))
@@ -462,7 +462,8 @@ def _set_countries_and_substations(n):
     # TODO: At the moment buses["symbol"] = False. This was set as default values
     # and need to be adjusted. What values should we put in?
     # .str.contains("substation|converter station",
-    substation_b = buses["symbol"].str.contains("substation|converter station", case=False)
+    substation_b = buses["symbol"].str.contains(
+        "substation|converter station", case=False)
 
     #                                             case=False)
 
@@ -529,7 +530,8 @@ def _set_countries_and_substations(n):
                                      geometry=gpd.points_from_xy(
                                          bus_locations.x, bus_locations.y),
                                      crs=4326)
-    offshore_b = bus_locations.within(offshore_shapes)  # Check if bus is in shape
+    offshore_b = bus_locations.within(
+        offshore_shapes)  # Check if bus is in shape
 
     # Assumption that HV-bus qualifies as potential offshore bus. Offshore bus is empty otherwise.
     offshore_hvb = (

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -75,12 +75,10 @@ import scipy as sp
 import shapely.prepared
 import shapely.wkt
 import yaml
-from _helpers import _read_csv_nafix
-from _helpers import configure_logging
+from _helpers import _read_csv_nafix, configure_logging
 from osm_pbf_power_data_extractor import create_country_list
 from scipy.sparse import csgraph
-from shapely.geometry import LineString
-from shapely.geometry import Point
+from shapely.geometry import LineString, Point
 from shapely.ops import unary_union
 
 logger = logging.getLogger(__name__)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -461,7 +461,7 @@ def _set_countries_and_substations(n):
     # TODO: At the moment buses["symbol"] = False. This was set as default values
     # and need to be adjusted. What values should we put in?
     # .str.contains("substation|converter station",
-    substation_b = buses["symbol"]
+    substation_b = buses["symbol"].str.contains("substation|converter station", case=False)
 
     #                                             case=False)
 
@@ -743,6 +743,8 @@ def base_network():
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
+
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
         snakemake = mock_snakemake("base_network")
     configure_logging(snakemake)

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -45,16 +45,15 @@ The configuration options ``electricity: powerplants_filter`` and ``electricity:
         custom_powerplants: YearCommissioned <= 2015
 """
 
-import yaml
-import os
 import logging
-from _helpers import configure_logging
+import os
 
-import pypsa
-import powerplantmatching as pm
-import pandas as pd
 import numpy as np
-
+import pandas as pd
+import powerplantmatching as pm
+import pypsa
+import yaml
+from _helpers import configure_logging
 from scipy.spatial import cKDTree as KDTree
 
 logger = logging.getLogger(__name__)

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -61,23 +61,24 @@ logger = logging.getLogger(__name__)
 
 
 def add_custom_powerplants(ppl):
-    custom_ppl_query = snakemake.config['electricity']['custom_powerplants']
+    custom_ppl_query = snakemake.config["electricity"]["custom_powerplants"]
     if not custom_ppl_query:
         return ppl
-    add_ppls = pd.read_csv(snakemake.input.custom_powerplants, index_col=0,
-                           dtype={'bus': 'str'})
+    add_ppls = pd.read_csv(
+        snakemake.input.custom_powerplants, index_col=0, dtype={"bus": "str"}
+    )
     if isinstance(custom_ppl_query, str):
         add_ppls.query(custom_ppl_query, inplace=True)
     return ppl.append(add_ppls, sort=False, ignore_index=True, verify_integrity=True)
 
 
 if __name__ == "__main__":
-    if 'snakemake' not in globals():
+    if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-        snakemake = mock_snakemake('build_powerplants')
+        snakemake = mock_snakemake("build_powerplants")
     configure_logging(snakemake)
 
     with open(snakemake.input.pm_config, "r") as f:
@@ -85,42 +86,44 @@ if __name__ == "__main__":
 
     n = pypsa.Network(snakemake.input.base_network)
     countries = n.buses.country.unique()
-    config['target_countries'] = countries
+    config["target_countries"] = countries
 
-    ppl = (pm.powerplants(from_url=False, config=config)
-           .powerplant.fill_missing_decommyears()
-           .query('Fueltype not in ["Solar", "Wind"] and Country in @countries')
-           .replace({'Technology': {'Steam Turbine': 'OCGT'}})
-           .assign(Fueltype=lambda df: (
-               df.Fueltype
-               .where(df.Fueltype != 'Natural Gas',
-                      df.Technology.replace('Steam Turbine',
-                                            'OCGT').fillna('OCGT')))))
+    ppl = (
+        pm.powerplants(from_url=False, config=config)
+        .powerplant.fill_missing_decommyears()
+        .query('Fueltype not in ["Solar", "Wind"] and Country in @countries')
+        .replace({"Technology": {"Steam Turbine": "OCGT"}})
+        .assign(
+            Fueltype=lambda df: (
+                df.Fueltype.where(
+                    df.Fueltype != "Natural Gas",
+                    df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
+                )
+            )
+        )
+    )
 
-    ppl_query = snakemake.config['electricity']['powerplants_filter']
+    ppl_query = snakemake.config["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):
         ppl.query(ppl_query, inplace=True)
 
     # ppl = add_custom_powerplants(ppl) # add carriers from own powerplant files
 
-    cntries_without_ppl = [
-        c for c in countries if c not in ppl.Country.unique()]
+    cntries_without_ppl = [c for c in countries if c not in ppl.Country.unique()]
 
     for c in countries:
-        substation_i = n.buses.query('substation_lv and country == @c').index
-        kdtree = KDTree(n.buses.loc[substation_i, ['x', 'y']].values)
-        ppl_i = ppl.query('Country == @c').index
+        substation_i = n.buses.query("substation_lv and country == @c").index
+        kdtree = KDTree(n.buses.loc[substation_i, ["x", "y"]].values)
+        ppl_i = ppl.query("Country == @c").index
 
-        tree_i = kdtree.query(ppl.loc[ppl_i, ['lon', 'lat']].values)[1]
-        ppl.loc[ppl_i, 'bus'] = substation_i.append(pd.Index([np.nan]))[tree_i]
+        tree_i = kdtree.query(ppl.loc[ppl_i, ["lon", "lat"]].values)[1]
+        ppl.loc[ppl_i, "bus"] = substation_i.append(pd.Index([np.nan]))[tree_i]
 
     if cntries_without_ppl:
-        logging.warning(
-            f"No powerplants known in: {', '.join(cntries_without_ppl)}")
+        logging.warning(f"No powerplants known in: {', '.join(cntries_without_ppl)}")
 
     bus_null_b = ppl["bus"].isnull()
     if bus_null_b.any():
-        logging.warning(
-            f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
+        logging.warning(f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
 
     ppl.to_csv(snakemake.output[0])

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: : 2017-2020 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT
-
 # coding: utf-8
 """
 Retrieves conventional powerplant capacities and locations from `powerplantmatching <https://github.com/FRESNA/powerplantmatching>`_, assigns these to buses and creates a ``.csv`` file. It is possible to amend the powerplant database with custom entries provided in ``data/custom_powerplants.csv``.
@@ -44,7 +43,6 @@ The configuration options ``electricity: powerplants_filter`` and ``electricity:
         powerplants_filter: Country not in ['Germany'] and YearCommissioned <= 2015
         custom_powerplants: YearCommissioned <= 2015
 """
-
 import logging
 import os
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -46,6 +46,7 @@ The configuration options ``electricity: powerplants_filter`` and ``electricity:
 """
 
 import yaml
+import os
 import logging
 from _helpers import configure_logging
 
@@ -73,6 +74,9 @@ def add_custom_powerplants(ppl):
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from _helpers import mock_snakemake
+
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
         snakemake = mock_snakemake('build_powerplants')
     configure_logging(snakemake)
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake('build_powerplants')
-    
+
     configure_logging(snakemake)
 
     with open(snakemake.input.pm_config, "r") as f:
@@ -90,14 +90,14 @@ if __name__ == "__main__":
         from_url=False,
         config=config).powerplant.fill_missing_decommyears().query(
             'Fueltype not in ["Solar", "Wind"] and Country in @countries').
-           replace({
-               "Technology": {
-                   "Steam Turbine": "OCGT"
-               }
-           }).assign(Fueltype=lambda df: (df.Fueltype.where(
-               df.Fueltype != "Natural Gas",
-               df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
-           ))))
+        replace({
+            "Technology": {
+                "Steam Turbine": "OCGT"
+            }
+        }).assign(Fueltype=lambda df: (df.Fueltype.where(
+            df.Fueltype != "Natural Gas",
+            df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
+        ))))
 
     ppl_query = snakemake.config["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -61,12 +61,15 @@ def add_custom_powerplants(ppl):
     custom_ppl_query = snakemake.config["electricity"]["custom_powerplants"]
     if not custom_ppl_query:
         return ppl
-    add_ppls = pd.read_csv(
-        snakemake.input.custom_powerplants, index_col=0, dtype={"bus": "str"}
-    )
+    add_ppls = pd.read_csv(snakemake.input.custom_powerplants,
+                           index_col=0,
+                           dtype={"bus": "str"})
     if isinstance(custom_ppl_query, str):
         add_ppls.query(custom_ppl_query, inplace=True)
-    return ppl.append(add_ppls, sort=False, ignore_index=True, verify_integrity=True)
+    return ppl.append(add_ppls,
+                      sort=False,
+                      ignore_index=True,
+                      verify_integrity=True)
 
 
 if __name__ == "__main__":
@@ -85,20 +88,18 @@ if __name__ == "__main__":
     countries = n.buses.country.unique()
     config["target_countries"] = countries
 
-    ppl = (
-        pm.powerplants(from_url=False, config=config)
-        .powerplant.fill_missing_decommyears()
-        .query('Fueltype not in ["Solar", "Wind"] and Country in @countries')
-        .replace({"Technology": {"Steam Turbine": "OCGT"}})
-        .assign(
-            Fueltype=lambda df: (
-                df.Fueltype.where(
-                    df.Fueltype != "Natural Gas",
-                    df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
-                )
-            )
-        )
-    )
+    ppl = (pm.powerplants(
+        from_url=False,
+        config=config).powerplant.fill_missing_decommyears().query(
+            'Fueltype not in ["Solar", "Wind"] and Country in @countries').
+           replace({
+               "Technology": {
+                   "Steam Turbine": "OCGT"
+               }
+           }).assign(Fueltype=lambda df: (df.Fueltype.where(
+               df.Fueltype != "Natural Gas",
+               df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
+           ))))
 
     ppl_query = snakemake.config["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):
@@ -106,7 +107,9 @@ if __name__ == "__main__":
 
     # ppl = add_custom_powerplants(ppl) # add carriers from own powerplant files
 
-    cntries_without_ppl = [c for c in countries if c not in ppl.Country.unique()]
+    cntries_without_ppl = [
+        c for c in countries if c not in ppl.Country.unique()
+    ]
 
     for c in countries:
         substation_i = n.buses.query("substation_lv and country == @c").index
@@ -117,10 +120,12 @@ if __name__ == "__main__":
         ppl.loc[ppl_i, "bus"] = substation_i.append(pd.Index([np.nan]))[tree_i]
 
     if cntries_without_ppl:
-        logging.warning(f"No powerplants known in: {', '.join(cntries_without_ppl)}")
+        logging.warning(
+            f"No powerplants known in: {', '.join(cntries_without_ppl)}")
 
     bus_null_b = ppl["bus"].isnull()
     if bus_null_b.any():
-        logging.warning(f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
+        logging.warning(
+            f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
 
     ppl.to_csv(snakemake.output[0])

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -60,22 +60,20 @@ def add_custom_powerplants(ppl):
     custom_ppl_query = snakemake.config["electricity"]["custom_powerplants"]
     if not custom_ppl_query:
         return ppl
-    add_ppls = pd.read_csv(snakemake.input.custom_powerplants,
-                           index_col=0,
-                           dtype={"bus": "str"})
+    add_ppls = pd.read_csv(
+        snakemake.input.custom_powerplants, index_col=0, dtype={"bus": "str"}
+    )
     if isinstance(custom_ppl_query, str):
         add_ppls.query(custom_ppl_query, inplace=True)
-    return ppl.append(add_ppls,
-                      sort=False,
-                      ignore_index=True,
-                      verify_integrity=True)
+    return ppl.append(add_ppls, sort=False, ignore_index=True, verify_integrity=True)
 
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
+
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake('build_powerplants')
+        snakemake = mock_snakemake("build_powerplants")
 
     configure_logging(snakemake)
 
@@ -86,18 +84,20 @@ if __name__ == "__main__":
     countries = n.buses.country.unique()
     config["target_countries"] = countries
 
-    ppl = (pm.powerplants(
-        from_url=False,
-        config=config).powerplant.fill_missing_decommyears().query(
-            'Fueltype not in ["Solar", "Wind"] and Country in @countries').
-        replace({
-            "Technology": {
-                "Steam Turbine": "OCGT"
-            }
-        }).assign(Fueltype=lambda df: (df.Fueltype.where(
-            df.Fueltype != "Natural Gas",
-            df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
-        ))))
+    ppl = (
+        pm.powerplants(from_url=False, config=config)
+        .powerplant.fill_missing_decommyears()
+        .query('Fueltype not in ["Solar", "Wind"] and Country in @countries')
+        .replace({"Technology": {"Steam Turbine": "OCGT"}})
+        .assign(
+            Fueltype=lambda df: (
+                df.Fueltype.where(
+                    df.Fueltype != "Natural Gas",
+                    df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
+                )
+            )
+        )
+    )
 
     ppl_query = snakemake.config["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):
@@ -105,9 +105,7 @@ if __name__ == "__main__":
 
     # ppl = add_custom_powerplants(ppl) # add carriers from own powerplant files
 
-    cntries_without_ppl = [
-        c for c in countries if c not in ppl.Country.unique()
-    ]
+    cntries_without_ppl = [c for c in countries if c not in ppl.Country.unique()]
 
     for c in countries:
         substation_i = n.buses.query("substation_lv and country == @c").index
@@ -118,12 +116,10 @@ if __name__ == "__main__":
         ppl.loc[ppl_i, "bus"] = substation_i.append(pd.Index([np.nan]))[tree_i]
 
     if cntries_without_ppl:
-        logging.warning(
-            f"No powerplants known in: {', '.join(cntries_without_ppl)}")
+        logging.warning(f"No powerplants known in: {', '.join(cntries_without_ppl)}")
 
     bus_null_b = ppl["bus"].isnull()
     if bus_null_b.any():
-        logging.warning(
-            f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
+        logging.warning(f"Couldn't find close bus for {bus_null_b.sum()} powerplants")
 
     ppl.to_csv(snakemake.output[0])

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -92,14 +92,14 @@ if __name__ == "__main__":
         from_url=False,
         config=config).powerplant.fill_missing_decommyears().query(
             'Fueltype not in ["Solar", "Wind"] and Country in @countries').
-           replace({
-               "Technology": {
-                   "Steam Turbine": "OCGT"
-               }
-           }).assign(Fueltype=lambda df: (df.Fueltype.where(
-               df.Fueltype != "Natural Gas",
-               df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
-           ))))
+        replace({
+            "Technology": {
+                "Steam Turbine": "OCGT"
+            }
+        }).assign(Fueltype=lambda df: (df.Fueltype.where(
+            df.Fueltype != "Natural Gas",
+            df.Technology.replace("Steam Turbine", "OCGT").fillna("OCGT"),
+        ))))
 
     ppl_query = snakemake.config["electricity"]["powerplants_filter"]
     if isinstance(ppl_query, str):

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -45,6 +45,7 @@ The configuration options ``electricity: powerplants_filter`` and ``electricity:
 """
 import logging
 import os
+
 import numpy as np
 import pandas as pd
 import powerplantmatching as pm

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -13,12 +13,17 @@ import rasterio
 import requests
 import rioxarray as rx
 import xarray as xr
-from _helpers import (_sets_path_to_root, _three_2_two_digits_country,
-                      _two_2_three_digits_country, _two_digits_2_name_country,
-                      configure_logging)
+from _helpers import _sets_path_to_root
+from _helpers import _three_2_two_digits_country
+from _helpers import _two_2_three_digits_country
+from _helpers import _two_digits_2_name_country
+from _helpers import configure_logging
 from osm_pbf_power_data_extractor import create_country_list
 from rasterio.mask import mask
-from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+from shapely.geometry import LineString
+from shapely.geometry import MultiPolygon
+from shapely.geometry import Point
+from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -139,7 +139,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
 
         # convert country name representation of the main country (GID_0 column)
         geodf_temp["GID_0"] = [
-            _three_2_two_digits_country(twoD_c) for twoD_c in geodf_temp["GID_0"]
+            _three_2_two_digits_country(twoD_c)
+            for twoD_c in geodf_temp["GID_0"]
         ]
 
         # create a subindex column that is useful
@@ -154,7 +155,10 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
     return geodf_GADM
 
 
-def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
+def _simplify_polys(polys,
+                    minarea=0.0001,
+                    tolerance=0.008,
+                    filterremote=False):
     "Function to simplify the shape polygons"
     if isinstance(polys, MultiPolygon):
         # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
@@ -162,13 +166,10 @@ def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
         mainpoly = polys[0]
         mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
         if mainpoly.area > minarea:
-            polys = MultiPolygon(
-                [
-                    p
-                    for p in takewhile(lambda p: p.area > minarea, polys)
-                    if not filterremote or (mainpoly.distance(p) < mainlength)
-                ]
-            )
+            polys = MultiPolygon([
+                p for p in takewhile(lambda p: p.area > minarea, polys)
+                if not filterremote or (mainpoly.distance(p) < mainlength)
+            ])
         else:
             polys = mainpoly
     return polys.simplify(tolerance=tolerance)
@@ -196,7 +197,8 @@ def countries(countries, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False):
 
     if out_logging:
-        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
+        _logger.info(
+            "Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = list(country_shapes)
     if eez_shapes is not None:
@@ -247,12 +249,11 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     selected_countries_codes_3D = [
         _two_2_three_digits_country(x) for x in countries_codes
     ]
-    geodf_EEZ = geodf_EEZ[
-        [any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]]
-    ]
+    geodf_EEZ = geodf_EEZ[[
+        any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]
+    ]]
     geodf_EEZ["ISO_TER1"] = geodf_EEZ["ISO_TER1"].map(
-        lambda x: _three_2_two_digits_country(x)
-    )
+        lambda x: _three_2_two_digits_country(x))
     geodf_EEZ.reset_index(drop=True, inplace=True)
 
     geodf_EEZ.rename(columns={"ISO_TER1": "name"}, inplace=True)
@@ -345,13 +346,14 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
 
             geom = ret_df[selection].geometry.unary_union
             ret_df.drop(ret_df[selection].index, inplace=True)
-            ret_df = ret_df.append(
-                {"name": c_code, "geometry": geom}, ignore_index=True
-            )
+            ret_df = ret_df.append({
+                "name": c_code,
+                "geometry": geom
+            },
+                                   ignore_index=True)
 
     ret_df = ret_df.set_index("name")["geometry"].map(
-        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001)
-    )
+        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
 
     # hole lies outside occurs here
     ret_df = ret_df.apply(lambda x: make_valid(x))
@@ -361,11 +363,8 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     ret_df_new = ret_df.difference(country_shapes_with_buffer)
 
     # repeat to simplify after the buffer correction
-    ret_df_new = ret_df_new.map(
-        lambda x: x
-        if x is None
-        else _simplify_polys(x, minarea=0.001, tolerance=0.0001)
-    )
+    ret_df_new = ret_df_new.map(lambda x: x if x is None else _simplify_polys(
+        x, minarea=0.001, tolerance=0.0001))
     ret_df_new = ret_df_new.apply(lambda x: x if x is None else make_valid(x))
 
     # Drops empty geometry
@@ -374,9 +373,11 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     return ret_df
 
 
-def download_WorldPop(
-    country_code, year=2020, update=False, out_logging=False, size_min=300
-):
+def download_WorldPop(country_code,
+                      year=2020,
+                      update=False,
+                      out_logging=False,
+                      size_min=300):
     """
     Download tiff file for each country code
 
@@ -414,9 +415,8 @@ def download_WorldPop(
         f"https://data.worldpop.org/GIS/Population/Global_2000_2020_Constrained/2020/maxar_v1/{_two_2_three_digits_country(country_code).upper()}/{WorldPop_filename}",
     ]
 
-    WorldPop_inputfile = os.path.join(
-        os.getcwd(), "data", "raw", "WorldPop", WorldPop_filename
-    )  # Input filepath tif
+    WorldPop_inputfile = os.path.join(os.getcwd(), "data", "raw", "WorldPop",
+                                      WorldPop_filename)  # Input filepath tif
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
         if out_logging:
@@ -435,7 +435,8 @@ def download_WorldPop(
                         loaded = True
                         break
         if not loaded:
-            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            _logger.error(
+                f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -453,14 +454,12 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     name_file_tif = name_file_nc[:-2] + "tif"
 
     # path of the nc file
-    GDP_nc = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_nc
-    )  # Input filepath nc
+    GDP_nc = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                          name_file_nc)  # Input filepath nc
 
     # path of the tif file
-    GDP_tif = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_tif
-    )  # Input filepath nc
+    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                           name_file_tif)  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
     if not os.path.exists(GDP_nc):
@@ -504,9 +503,8 @@ def load_GDP(
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
-    GDP_tif = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_tif
-    )  # Input filepath tif
+    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                           name_file_tif)  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:
@@ -553,9 +551,11 @@ def add_gdp_data(
             #   where the border of the shape lays. This may affect the computation
             #   but it is conservative and avoids considering multiple times the same
             #   pixels
-            out_image, out_transform = generalized_mask(
-                src, row["geometry"], all_touched=True, invert=False, nodata=0.0
-            )
+            out_image, out_transform = generalized_mask(src,
+                                                        row["geometry"],
+                                                        all_touched=True,
+                                                        invert=False,
+                                                        nodata=0.0)
             # out_image_int, out_transform = mask(src,
             #                                row["geometry"],
             #                                all_touched=False,
@@ -567,21 +567,19 @@ def add_gdp_data(
             # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
             if out_logging == True:
-                _logger.info(
-                    "Stage 4/4 GDP: shape: "
-                    + str(index)
-                    + " out of "
-                    + str(df_gadm.shape[0])
-                )
+                _logger.info("Stage 4/4 GDP: shape: " + str(index) +
+                             " out of " + str(df_gadm.shape[0]))
 
             # update the gdp data in the dataset
             df_gadm.loc[index, "gdp"] = gdp_by_geom
     return df_gadm
 
 
-def add_population_data(
-    df_gadm, country_codes, year=2020, update=False, out_logging=False
-):
+def add_population_data(df_gadm,
+                        country_codes,
+                        year=2020,
+                        update=False,
+                        out_logging=False):
     """Function to add the population info for each country shape in the gadm dataset"""
 
     if out_logging:
@@ -595,8 +593,7 @@ def add_population_data(
 
     for c_code in country_codes:
         WorldPop_inputfile, WorldPop_filename = download_WorldPop(
-            c_code, year, update, out_logging
-        )
+            c_code, year, update, out_logging)
 
         with rasterio.open(WorldPop_inputfile) as src:
             country_rows = df_gadm.loc[df_gadm["country"] == c_code]
@@ -607,9 +604,11 @@ def add_population_data(
                 #   where the border of the shape lays. This leads to slightly overestimate
                 #   the population, but the error is limited and it enables halving the
                 #   computational time
-                out_image, out_transform = generalized_mask(
-                    src, row["geometry"], all_touched=True, invert=False, nodata=0.0
-                )
+                out_image, out_transform = generalized_mask(src,
+                                                            row["geometry"],
+                                                            all_touched=True,
+                                                            invert=False,
+                                                            nodata=0.0)
                 # out_image_int, out_transform = mask(src,
                 #                                row["geometry"],
                 #                                all_touched=False,
@@ -626,15 +625,8 @@ def add_population_data(
                 count += 1
 
                 if out_logging == True:
-                    _logger.info(
-                        "Stage 4/4 POP: "
-                        + str(count)
-                        + " out of "
-                        + str(df_gadm.shape[0])
-                        + " ["
-                        + c_code
-                        + "]"
-                    )
+                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " +
+                                 str(df_gadm.shape[0]) + " [" + c_code + "]")
                     # print(c_code, ": ", index, " out of ",
                     #      country_rows.shape[0])
 
@@ -696,7 +688,8 @@ if __name__ == "__main__":
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
+    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg,
+                          out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -350,7 +350,7 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
                 "name": c_code,
                 "geometry": geom
             },
-                                   ignore_index=True)
+                ignore_index=True)
 
     ret_df = ret_df.set_index("name")["geometry"].map(
         lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -13,17 +13,12 @@ import rasterio
 import requests
 import rioxarray as rx
 import xarray as xr
-from _helpers import _sets_path_to_root
-from _helpers import _three_2_two_digits_country
-from _helpers import _two_2_three_digits_country
-from _helpers import _two_digits_2_name_country
-from _helpers import configure_logging
+from _helpers import (_sets_path_to_root, _three_2_two_digits_country,
+                      _two_2_three_digits_country, _two_digits_2_name_country,
+                      configure_logging)
 from osm_pbf_power_data_extractor import create_country_list
 from rasterio.mask import mask
-from shapely.geometry import LineString
-from shapely.geometry import MultiPolygon
-from shapely.geometry import Point
-from shapely.geometry import Polygon
+from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -32,7 +32,7 @@ _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
 # IMPORTANT: RUN SCRIPT FROM THIS SCRIPTS DIRECTORY i.e data_exploration/ TODO: make more robust
-#os.chdir(os.path.dirname(os.path.abspath(__file__)))
+# os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 # import sys
 
@@ -155,7 +155,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
 def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
     "Function to simplify the shape polygons"
     if isinstance(polys, MultiPolygon):
-        polys = sorted(polys, key=attrgetter("area"), reverse=True) # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
+        # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
+        polys = sorted(polys, key=attrgetter("area"), reverse=True)
         mainpoly = polys[0]
         mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
         if mainpoly.area > minarea:
@@ -190,7 +191,8 @@ def countries(countries, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False):
 
     if out_logging:
-        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
+        _logger.info(
+            "Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = list(country_shapes)
     if eez_shapes is not None:
@@ -202,7 +204,8 @@ def country_cover(country_shapes, eez_shapes=None, out_logging=False):
     return Polygon(shell=africa_shape.exterior)
 
 
-def save_to_geojson(df, fn): # error occurs here: ERROR:shapely.geos:IllegalArgumentException: Geometry must be a Point or LineString
+# error occurs here: ERROR:shapely.geos:IllegalArgumentException: Geometry must be a Point or LineString
+def save_to_geojson(df, fn):
     if os.path.exists(fn):
         os.unlink(fn)  # remove file if it exists
     if not isinstance(df, gpd.GeoDataFrame):
@@ -268,7 +271,7 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
 
 #         if n_offshore_shapes > 1:
 #             # when multiple shapes per country, then merge polygons
-            
+
 #             geom = ret_df_old[selection].geometry.unary_union
 #             ret_df_old.drop(ret_df_old[selection].index, inplace=True)
 #             ret_df_old = ret_df_old.append({"name": c_code, "geometry": geom}, ignore_index=True)
@@ -317,7 +320,6 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     """
     from shapely.validation import make_valid
 
-    
     if out_logging:
         _logger.info("Stage 2 of 4: Create offshore shapes")
 
@@ -327,7 +329,7 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     # simplified offshore_shape
     # ret_df = df_eez.set_index("name")["geometry"].map(
     #     lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
-    
+
     ret_df = df_eez[["name", "geometry"]]
     # create unique shape if country is described by multiple shapes
     for c_code in countries:
@@ -336,16 +338,17 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
 
         if n_offshore_shapes > 1:
             # when multiple shapes per country, then merge polygons
-            
+
             geom = ret_df[selection].geometry.unary_union
             ret_df.drop(ret_df[selection].index, inplace=True)
-            ret_df = ret_df.append({"name": c_code, "geometry": geom}, ignore_index=True)
+            ret_df = ret_df.append(
+                {"name": c_code, "geometry": geom}, ignore_index=True)
 
     ret_df = ret_df.set_index("name")["geometry"].map(
         lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
 
-
-    ret_df = ret_df.apply(lambda x: make_valid(x))  # hole lies outside occurs here
+    # hole lies outside occurs here
+    ret_df = ret_df.apply(lambda x: make_valid(x))
     country_shapes = country_shapes.apply(lambda x: make_valid(x))
 
     country_shapes_with_buffer = country_shapes.buffer(distance)
@@ -425,7 +428,8 @@ def download_WorldPop(country_code,
                         loaded = True
                         break
         if not loaded:
-            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            _logger.error(
+                f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -541,10 +545,10 @@ def add_gdp_data(
             #   but it is conservative and avoids considering multiple times the same
             #   pixels
             out_image, out_transform = generalized_mask(src,
-                                            row["geometry"],
-                                            all_touched=True,
-                                            invert=False,
-                                            nodata=0.0)
+                                                        row["geometry"],
+                                                        all_touched=True,
+                                                        invert=False,
+                                                        nodata=0.0)
             # out_image_int, out_transform = mask(src,
             #                                row["geometry"],
             #                                all_touched=False,
@@ -556,12 +560,12 @@ def add_gdp_data(
             # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
             if out_logging == True:
-                _logger.info("Stage 4/4 GDP: shape: " + str(index) + " out of " + str(df_gadm.shape[0]))
+                _logger.info("Stage 4/4 GDP: shape: " +
+                             str(index) + " out of " + str(df_gadm.shape[0]))
 
             # update the gdp data in the dataset
             df_gadm.loc[index, "gdp"] = gdp_by_geom
     return df_gadm
-
 
 
 def add_population_data(df_gadm,
@@ -594,10 +598,10 @@ def add_population_data(df_gadm,
                 #   the population, but the error is limited and it enables halving the
                 #   computational time
                 out_image, out_transform = generalized_mask(src,
-                                            row["geometry"],
-                                            all_touched=True,
-                                            invert=False,
-                                            nodata=0.0)
+                                                            row["geometry"],
+                                                            all_touched=True,
+                                                            invert=False,
+                                                            nodata=0.0)
                 # out_image_int, out_transform = mask(src,
                 #                                row["geometry"],
                 #                                all_touched=False,
@@ -614,7 +618,8 @@ def add_population_data(df_gadm,
                 count += 1
 
                 if out_logging == True:
-                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " + str(df_gadm.shape[0]) + " [" + c_code + "]")
+                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " +
+                                 str(df_gadm.shape[0]) + " [" + c_code + "]")
                     # print(c_code, ": ", index, " out of ",
                     #      country_rows.shape[0])
 
@@ -675,7 +680,8 @@ if __name__ == "__main__":
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
+    offshore_shapes = eez(countries_list, country_shapes,
+                          EEZ_gpkg, out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -11,17 +11,22 @@ import geopandas as gpd
 import numpy as np
 import rasterio
 import requests
-# import rioxarray
 import rioxarray as rx
 import xarray as xr
-from _helpers import (_sets_path_to_root, _three_2_two_digits_country,
-                      _two_2_three_digits_country, _two_digits_2_name_country,
-                      configure_logging)
+from _helpers import _sets_path_to_root
+from _helpers import _three_2_two_digits_country
+from _helpers import _two_2_three_digits_country
+from _helpers import _two_digits_2_name_country
+from _helpers import configure_logging
 from osm_pbf_power_data_extractor import create_country_list
 from rasterio.mask import mask
-from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+from shapely.geometry import LineString
+from shapely.geometry import MultiPolygon
+from shapely.geometry import Point
+from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
+# import rioxarray
 
 # from osm_data_config import AFRICA_CC
 

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -349,7 +349,7 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
                 "name": c_code,
                 "geometry": geom
             },
-                                   ignore_index=True)
+                ignore_index=True)
 
     ret_df = ret_df.set_index("name")["geometry"].map(
         lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -219,18 +219,18 @@ def save_to_geojson(df, fn): # error occurs here: ERROR:shapely.geos:IllegalArgu
             pass
 
 
-def load_EEZ(countries_codes, name_file="eez_v11.gpkg"):
+def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     """
     Function to load the database of the Exclusive Economic Zones.
     The dataset shall be downloaded independently by the user (see guide) or toghether with pypsa-africa package.
     """
 
-    EEZ_gpkg = os.path.join(os.getcwd(), "data", "raw", "eez",
-                            name_file)  # Input filepath gpkg
+    # EEZ_gpkg = os.path.join(os.getcwd(), "data", "raw", "eez",
+    #                         name_file)  # Input filepath gpkg
 
     if not os.path.exists(EEZ_gpkg):
         raise Exception(
-            f"File EEZ {name_file} not found, please download it from https://www.marineregions.org/download_file.php?name=World_EEZ_v11_20191118_gpkg.zip and copy it in {os.path.dirname(EEZ_gpkg)}"
+            f"File EEZ {EEZ_gpkg} not found, please download it from https://www.marineregions.org/download_file.php?name=World_EEZ_v11_20191118_gpkg.zip and copy it in {os.path.dirname(EEZ_gpkg)}"
         )
 
     geodf_EEZ = gpd.read_file(EEZ_gpkg)
@@ -307,7 +307,7 @@ def load_EEZ(countries_codes, name_file="eez_v11.gpkg"):
 #     return ret_df
 
 
-def eez(countries, country_shapes, out_logging=False, distance=0.01):
+def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     """
     Creates offshore shapes by 
     - buffer smooth countryshape (=offset country shape)
@@ -322,7 +322,7 @@ def eez(countries, country_shapes, out_logging=False, distance=0.01):
         _logger.info("Stage 2 of 4: Create offshore shapes")
 
     # load data
-    df_eez = load_EEZ(countries)
+    df_eez = load_EEZ(countries, EEZ_gpkg)
 
     # simplified offshore_shape
     # ret_df = df_eez.set_index("name")["geometry"].map(
@@ -668,13 +668,14 @@ if __name__ == "__main__":
     update = snakemake.config['build_shape_options']['update_file']
     out_logging = snakemake.config['build_shape_options']['out_logging']
     year = snakemake.config['build_shape_options']['year']
+    EEZ_gpkg = snakemake.input["eez"]
 
     # print(snakemake.config)
 
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, out_logging)
+    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -11,20 +11,16 @@ import geopandas as gpd
 import numpy as np
 import rasterio
 import requests
-
 # import rioxarray
 import rioxarray as rx
-from shapely.geometry.base import BaseGeometry
 import xarray as xr
-from _helpers import _sets_path_to_root
-from _helpers import _three_2_two_digits_country
-from _helpers import _two_2_three_digits_country
-from _helpers import _two_digits_2_name_country
-from _helpers import configure_logging
+from _helpers import (_sets_path_to_root, _three_2_two_digits_country,
+                      _two_2_three_digits_country, _two_digits_2_name_country,
+                      configure_logging)
 from osm_pbf_power_data_extractor import create_country_list
 from rasterio.mask import mask
-from shapely.geometry import MultiPolygon
-from shapely.geometry import Polygon, Point, LineString
+from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
 
 # from osm_data_config import AFRICA_CC

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -26,6 +26,7 @@ from shapely.geometry import Point
 from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
+
 # import rioxarray
 
 # from osm_data_config import AFRICA_CC
@@ -138,8 +139,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
 
         # convert country name representation of the main country (GID_0 column)
         geodf_temp["GID_0"] = [
-            _three_2_two_digits_country(twoD_c)
-            for twoD_c in geodf_temp["GID_0"]
+            _three_2_two_digits_country(twoD_c) for twoD_c in geodf_temp["GID_0"]
         ]
 
         # create a subindex column that is useful
@@ -154,10 +154,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
     return geodf_GADM
 
 
-def _simplify_polys(polys,
-                    minarea=0.0001,
-                    tolerance=0.008,
-                    filterremote=False):
+def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
     "Function to simplify the shape polygons"
     if isinstance(polys, MultiPolygon):
         # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
@@ -165,10 +162,13 @@ def _simplify_polys(polys,
         mainpoly = polys[0]
         mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
         if mainpoly.area > minarea:
-            polys = MultiPolygon([
-                p for p in takewhile(lambda p: p.area > minarea, polys)
-                if not filterremote or (mainpoly.distance(p) < mainlength)
-            ])
+            polys = MultiPolygon(
+                [
+                    p
+                    for p in takewhile(lambda p: p.area > minarea, polys)
+                    if not filterremote or (mainpoly.distance(p) < mainlength)
+                ]
+            )
         else:
             polys = mainpoly
     return polys.simplify(tolerance=tolerance)
@@ -196,8 +196,7 @@ def countries(countries, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False):
 
     if out_logging:
-        _logger.info(
-            "Stage 3 of 4: Merge country shapes to create continent shape")
+        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = list(country_shapes)
     if eez_shapes is not None:
@@ -248,11 +247,12 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     selected_countries_codes_3D = [
         _two_2_three_digits_country(x) for x in countries_codes
     ]
-    geodf_EEZ = geodf_EEZ[[
-        any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]
-    ]]
+    geodf_EEZ = geodf_EEZ[
+        [any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]]
+    ]
     geodf_EEZ["ISO_TER1"] = geodf_EEZ["ISO_TER1"].map(
-        lambda x: _three_2_two_digits_country(x))
+        lambda x: _three_2_two_digits_country(x)
+    )
     geodf_EEZ.reset_index(drop=True, inplace=True)
 
     geodf_EEZ.rename(columns={"ISO_TER1": "name"}, inplace=True)
@@ -345,14 +345,13 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
 
             geom = ret_df[selection].geometry.unary_union
             ret_df.drop(ret_df[selection].index, inplace=True)
-            ret_df = ret_df.append({
-                "name": c_code,
-                "geometry": geom
-            },
-                ignore_index=True)
+            ret_df = ret_df.append(
+                {"name": c_code, "geometry": geom}, ignore_index=True
+            )
 
     ret_df = ret_df.set_index("name")["geometry"].map(
-        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
+        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001)
+    )
 
     # hole lies outside occurs here
     ret_df = ret_df.apply(lambda x: make_valid(x))
@@ -362,8 +361,11 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     ret_df_new = ret_df.difference(country_shapes_with_buffer)
 
     # repeat to simplify after the buffer correction
-    ret_df_new = ret_df_new.map(lambda x: x if x is None else _simplify_polys(
-        x, minarea=0.001, tolerance=0.0001))
+    ret_df_new = ret_df_new.map(
+        lambda x: x
+        if x is None
+        else _simplify_polys(x, minarea=0.001, tolerance=0.0001)
+    )
     ret_df_new = ret_df_new.apply(lambda x: x if x is None else make_valid(x))
 
     # Drops empty geometry
@@ -372,11 +374,9 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     return ret_df
 
 
-def download_WorldPop(country_code,
-                      year=2020,
-                      update=False,
-                      out_logging=False,
-                      size_min=300):
+def download_WorldPop(
+    country_code, year=2020, update=False, out_logging=False, size_min=300
+):
     """
     Download tiff file for each country code
 
@@ -414,8 +414,9 @@ def download_WorldPop(country_code,
         f"https://data.worldpop.org/GIS/Population/Global_2000_2020_Constrained/2020/maxar_v1/{_two_2_three_digits_country(country_code).upper()}/{WorldPop_filename}",
     ]
 
-    WorldPop_inputfile = os.path.join(os.getcwd(), "data", "raw", "WorldPop",
-                                      WorldPop_filename)  # Input filepath tif
+    WorldPop_inputfile = os.path.join(
+        os.getcwd(), "data", "raw", "WorldPop", WorldPop_filename
+    )  # Input filepath tif
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
         if out_logging:
@@ -434,8 +435,7 @@ def download_WorldPop(country_code,
                         loaded = True
                         break
         if not loaded:
-            _logger.error(
-                f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -453,12 +453,14 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     name_file_tif = name_file_nc[:-2] + "tif"
 
     # path of the nc file
-    GDP_nc = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                          name_file_nc)  # Input filepath nc
+    GDP_nc = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_nc
+    )  # Input filepath nc
 
     # path of the tif file
-    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                           name_file_tif)  # Input filepath nc
+    GDP_tif = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_tif
+    )  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
     if not os.path.exists(GDP_nc):
@@ -502,8 +504,9 @@ def load_GDP(
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
-    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                           name_file_tif)  # Input filepath tif
+    GDP_tif = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_tif
+    )  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:
@@ -550,11 +553,9 @@ def add_gdp_data(
             #   where the border of the shape lays. This may affect the computation
             #   but it is conservative and avoids considering multiple times the same
             #   pixels
-            out_image, out_transform = generalized_mask(src,
-                                                        row["geometry"],
-                                                        all_touched=True,
-                                                        invert=False,
-                                                        nodata=0.0)
+            out_image, out_transform = generalized_mask(
+                src, row["geometry"], all_touched=True, invert=False, nodata=0.0
+            )
             # out_image_int, out_transform = mask(src,
             #                                row["geometry"],
             #                                all_touched=False,
@@ -566,19 +567,21 @@ def add_gdp_data(
             # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
             if out_logging == True:
-                _logger.info("Stage 4/4 GDP: shape: " + str(index) +
-                             " out of " + str(df_gadm.shape[0]))
+                _logger.info(
+                    "Stage 4/4 GDP: shape: "
+                    + str(index)
+                    + " out of "
+                    + str(df_gadm.shape[0])
+                )
 
             # update the gdp data in the dataset
             df_gadm.loc[index, "gdp"] = gdp_by_geom
     return df_gadm
 
 
-def add_population_data(df_gadm,
-                        country_codes,
-                        year=2020,
-                        update=False,
-                        out_logging=False):
+def add_population_data(
+    df_gadm, country_codes, year=2020, update=False, out_logging=False
+):
     """Function to add the population info for each country shape in the gadm dataset"""
 
     if out_logging:
@@ -592,7 +595,8 @@ def add_population_data(df_gadm,
 
     for c_code in country_codes:
         WorldPop_inputfile, WorldPop_filename = download_WorldPop(
-            c_code, year, update, out_logging)
+            c_code, year, update, out_logging
+        )
 
         with rasterio.open(WorldPop_inputfile) as src:
             country_rows = df_gadm.loc[df_gadm["country"] == c_code]
@@ -603,11 +607,9 @@ def add_population_data(df_gadm,
                 #   where the border of the shape lays. This leads to slightly overestimate
                 #   the population, but the error is limited and it enables halving the
                 #   computational time
-                out_image, out_transform = generalized_mask(src,
-                                                            row["geometry"],
-                                                            all_touched=True,
-                                                            invert=False,
-                                                            nodata=0.0)
+                out_image, out_transform = generalized_mask(
+                    src, row["geometry"], all_touched=True, invert=False, nodata=0.0
+                )
                 # out_image_int, out_transform = mask(src,
                 #                                row["geometry"],
                 #                                all_touched=False,
@@ -624,8 +626,15 @@ def add_population_data(df_gadm,
                 count += 1
 
                 if out_logging == True:
-                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " +
-                                 str(df_gadm.shape[0]) + " [" + c_code + "]")
+                    _logger.info(
+                        "Stage 4/4 POP: "
+                        + str(count)
+                        + " out of "
+                        + str(df_gadm.shape[0])
+                        + " ["
+                        + c_code
+                        + "]"
+                    )
                     # print(c_code, ": ", index, " out of ",
                     #      country_rows.shape[0])
 
@@ -687,8 +696,7 @@ if __name__ == "__main__":
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg,
-                          out_logging)
+    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -139,8 +139,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
 
         # convert country name representation of the main country (GID_0 column)
         geodf_temp["GID_0"] = [
-            _three_2_two_digits_country(twoD_c)
-            for twoD_c in geodf_temp["GID_0"]
+            _three_2_two_digits_country(twoD_c) for twoD_c in geodf_temp["GID_0"]
         ]
 
         # create a subindex column that is useful
@@ -155,10 +154,7 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
     return geodf_GADM
 
 
-def _simplify_polys(polys,
-                    minarea=0.0001,
-                    tolerance=0.008,
-                    filterremote=False):
+def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
     "Function to simplify the shape polygons"
     if isinstance(polys, MultiPolygon):
         # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
@@ -166,10 +162,13 @@ def _simplify_polys(polys,
         mainpoly = polys[0]
         mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
         if mainpoly.area > minarea:
-            polys = MultiPolygon([
-                p for p in takewhile(lambda p: p.area > minarea, polys)
-                if not filterremote or (mainpoly.distance(p) < mainlength)
-            ])
+            polys = MultiPolygon(
+                [
+                    p
+                    for p in takewhile(lambda p: p.area > minarea, polys)
+                    if not filterremote or (mainpoly.distance(p) < mainlength)
+                ]
+            )
         else:
             polys = mainpoly
     return polys.simplify(tolerance=tolerance)
@@ -197,8 +196,7 @@ def countries(countries, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False):
 
     if out_logging:
-        _logger.info(
-            "Stage 3 of 4: Merge country shapes to create continent shape")
+        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = list(country_shapes)
     if eez_shapes is not None:
@@ -249,11 +247,12 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     selected_countries_codes_3D = [
         _two_2_three_digits_country(x) for x in countries_codes
     ]
-    geodf_EEZ = geodf_EEZ[[
-        any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]
-    ]]
+    geodf_EEZ = geodf_EEZ[
+        [any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]]
+    ]
     geodf_EEZ["ISO_TER1"] = geodf_EEZ["ISO_TER1"].map(
-        lambda x: _three_2_two_digits_country(x))
+        lambda x: _three_2_two_digits_country(x)
+    )
     geodf_EEZ.reset_index(drop=True, inplace=True)
 
     geodf_EEZ.rename(columns={"ISO_TER1": "name"}, inplace=True)
@@ -346,14 +345,13 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
 
             geom = ret_df[selection].geometry.unary_union
             ret_df.drop(ret_df[selection].index, inplace=True)
-            ret_df = ret_df.append({
-                "name": c_code,
-                "geometry": geom
-            },
-                ignore_index=True)
+            ret_df = ret_df.append(
+                {"name": c_code, "geometry": geom}, ignore_index=True
+            )
 
     ret_df = ret_df.set_index("name")["geometry"].map(
-        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
+        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001)
+    )
 
     # hole lies outside occurs here
     ret_df = ret_df.apply(lambda x: make_valid(x))
@@ -363,8 +361,11 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     ret_df_new = ret_df.difference(country_shapes_with_buffer)
 
     # repeat to simplify after the buffer correction
-    ret_df_new = ret_df_new.map(lambda x: x if x is None else _simplify_polys(
-        x, minarea=0.001, tolerance=0.0001))
+    ret_df_new = ret_df_new.map(
+        lambda x: x
+        if x is None
+        else _simplify_polys(x, minarea=0.001, tolerance=0.0001)
+    )
     ret_df_new = ret_df_new.apply(lambda x: x if x is None else make_valid(x))
 
     # Drops empty geometry
@@ -373,11 +374,9 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     return ret_df
 
 
-def download_WorldPop(country_code,
-                      year=2020,
-                      update=False,
-                      out_logging=False,
-                      size_min=300):
+def download_WorldPop(
+    country_code, year=2020, update=False, out_logging=False, size_min=300
+):
     """
     Download tiff file for each country code
 
@@ -415,8 +414,9 @@ def download_WorldPop(country_code,
         f"https://data.worldpop.org/GIS/Population/Global_2000_2020_Constrained/2020/maxar_v1/{_two_2_three_digits_country(country_code).upper()}/{WorldPop_filename}",
     ]
 
-    WorldPop_inputfile = os.path.join(os.getcwd(), "data", "raw", "WorldPop",
-                                      WorldPop_filename)  # Input filepath tif
+    WorldPop_inputfile = os.path.join(
+        os.getcwd(), "data", "raw", "WorldPop", WorldPop_filename
+    )  # Input filepath tif
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
         if out_logging:
@@ -435,8 +435,7 @@ def download_WorldPop(country_code,
                         loaded = True
                         break
         if not loaded:
-            _logger.error(
-                f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -454,12 +453,14 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     name_file_tif = name_file_nc[:-2] + "tif"
 
     # path of the nc file
-    GDP_nc = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                          name_file_nc)  # Input filepath nc
+    GDP_nc = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_nc
+    )  # Input filepath nc
 
     # path of the tif file
-    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                           name_file_tif)  # Input filepath nc
+    GDP_tif = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_tif
+    )  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
     if not os.path.exists(GDP_nc):
@@ -503,8 +504,9 @@ def load_GDP(
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
-    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
-                           name_file_tif)  # Input filepath tif
+    GDP_tif = os.path.join(
+        os.getcwd(), "data", "raw", "GDP", name_file_tif
+    )  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:
@@ -551,11 +553,9 @@ def add_gdp_data(
             #   where the border of the shape lays. This may affect the computation
             #   but it is conservative and avoids considering multiple times the same
             #   pixels
-            out_image, out_transform = generalized_mask(src,
-                                                        row["geometry"],
-                                                        all_touched=True,
-                                                        invert=False,
-                                                        nodata=0.0)
+            out_image, out_transform = generalized_mask(
+                src, row["geometry"], all_touched=True, invert=False, nodata=0.0
+            )
             # out_image_int, out_transform = mask(src,
             #                                row["geometry"],
             #                                all_touched=False,
@@ -567,19 +567,21 @@ def add_gdp_data(
             # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
             if out_logging == True:
-                _logger.info("Stage 4/4 GDP: shape: " + str(index) +
-                             " out of " + str(df_gadm.shape[0]))
+                _logger.info(
+                    "Stage 4/4 GDP: shape: "
+                    + str(index)
+                    + " out of "
+                    + str(df_gadm.shape[0])
+                )
 
             # update the gdp data in the dataset
             df_gadm.loc[index, "gdp"] = gdp_by_geom
     return df_gadm
 
 
-def add_population_data(df_gadm,
-                        country_codes,
-                        year=2020,
-                        update=False,
-                        out_logging=False):
+def add_population_data(
+    df_gadm, country_codes, year=2020, update=False, out_logging=False
+):
     """Function to add the population info for each country shape in the gadm dataset"""
 
     if out_logging:
@@ -593,7 +595,8 @@ def add_population_data(df_gadm,
 
     for c_code in country_codes:
         WorldPop_inputfile, WorldPop_filename = download_WorldPop(
-            c_code, year, update, out_logging)
+            c_code, year, update, out_logging
+        )
 
         with rasterio.open(WorldPop_inputfile) as src:
             country_rows = df_gadm.loc[df_gadm["country"] == c_code]
@@ -604,11 +607,9 @@ def add_population_data(df_gadm,
                 #   where the border of the shape lays. This leads to slightly overestimate
                 #   the population, but the error is limited and it enables halving the
                 #   computational time
-                out_image, out_transform = generalized_mask(src,
-                                                            row["geometry"],
-                                                            all_touched=True,
-                                                            invert=False,
-                                                            nodata=0.0)
+                out_image, out_transform = generalized_mask(
+                    src, row["geometry"], all_touched=True, invert=False, nodata=0.0
+                )
                 # out_image_int, out_transform = mask(src,
                 #                                row["geometry"],
                 #                                all_touched=False,
@@ -625,8 +626,15 @@ def add_population_data(df_gadm,
                 count += 1
 
                 if out_logging == True:
-                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " +
-                                 str(df_gadm.shape[0]) + " [" + c_code + "]")
+                    _logger.info(
+                        "Stage 4/4 POP: "
+                        + str(count)
+                        + " out of "
+                        + str(df_gadm.shape[0])
+                        + " ["
+                        + c_code
+                        + "]"
+                    )
                     # print(c_code, ": ", index, " out of ",
                     #      country_rows.shape[0])
 
@@ -688,8 +696,7 @@ if __name__ == "__main__":
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg,
-                          out_logging)
+    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -30,7 +30,6 @@ from shapely.ops import cascaded_union
 
 # from osm_data_config import AFRICA_CC
 
-
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
@@ -139,7 +138,8 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
 
         # convert country name representation of the main country (GID_0 column)
         geodf_temp["GID_0"] = [
-            _three_2_two_digits_country(twoD_c) for twoD_c in geodf_temp["GID_0"]
+            _three_2_two_digits_country(twoD_c)
+            for twoD_c in geodf_temp["GID_0"]
         ]
 
         # create a subindex column that is useful
@@ -154,7 +154,10 @@ def get_GADM_layer(country_list, layer_id, update=False, outlogging=False):
     return geodf_GADM
 
 
-def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
+def _simplify_polys(polys,
+                    minarea=0.0001,
+                    tolerance=0.008,
+                    filterremote=False):
     "Function to simplify the shape polygons"
     if isinstance(polys, MultiPolygon):
         # here deprecation warning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
@@ -162,13 +165,10 @@ def _simplify_polys(polys, minarea=0.0001, tolerance=0.008, filterremote=False):
         mainpoly = polys[0]
         mainlength = np.sqrt(mainpoly.area / (2.0 * np.pi))
         if mainpoly.area > minarea:
-            polys = MultiPolygon(
-                [
-                    p
-                    for p in takewhile(lambda p: p.area > minarea, polys)
-                    if not filterremote or (mainpoly.distance(p) < mainlength)
-                ]
-            )
+            polys = MultiPolygon([
+                p for p in takewhile(lambda p: p.area > minarea, polys)
+                if not filterremote or (mainpoly.distance(p) < mainlength)
+            ])
         else:
             polys = mainpoly
     return polys.simplify(tolerance=tolerance)
@@ -196,7 +196,8 @@ def countries(countries, update=False, out_logging=False):
 def country_cover(country_shapes, eez_shapes=None, out_logging=False):
 
     if out_logging:
-        _logger.info("Stage 3 of 4: Merge country shapes to create continent shape")
+        _logger.info(
+            "Stage 3 of 4: Merge country shapes to create continent shape")
 
     shapes = list(country_shapes)
     if eez_shapes is not None:
@@ -247,12 +248,11 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
     selected_countries_codes_3D = [
         _two_2_three_digits_country(x) for x in countries_codes
     ]
-    geodf_EEZ = geodf_EEZ[
-        [any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]]
-    ]
+    geodf_EEZ = geodf_EEZ[[
+        any([x in selected_countries_codes_3D]) for x in geodf_EEZ["ISO_TER1"]
+    ]]
     geodf_EEZ["ISO_TER1"] = geodf_EEZ["ISO_TER1"].map(
-        lambda x: _three_2_two_digits_country(x)
-    )
+        lambda x: _three_2_two_digits_country(x))
     geodf_EEZ.reset_index(drop=True, inplace=True)
 
     geodf_EEZ.rename(columns={"ISO_TER1": "name"}, inplace=True)
@@ -291,7 +291,6 @@ def load_EEZ(countries_codes, EEZ_gpkg="./data/raw/eez/eez_v11.gpkg"):
 #     ret_df_old.index.name = "name"
 
 #     return ret_df_old
-
 
 # def eez2(countries, country_shapes, update=False, out_logging=False, tol=1e-3):
 
@@ -346,13 +345,14 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
 
             geom = ret_df[selection].geometry.unary_union
             ret_df.drop(ret_df[selection].index, inplace=True)
-            ret_df = ret_df.append(
-                {"name": c_code, "geometry": geom}, ignore_index=True
-            )
+            ret_df = ret_df.append({
+                "name": c_code,
+                "geometry": geom
+            },
+                                   ignore_index=True)
 
     ret_df = ret_df.set_index("name")["geometry"].map(
-        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001)
-    )
+        lambda x: _simplify_polys(x, minarea=0.001, tolerance=0.0001))
 
     # hole lies outside occurs here
     ret_df = ret_df.apply(lambda x: make_valid(x))
@@ -362,11 +362,8 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     ret_df_new = ret_df.difference(country_shapes_with_buffer)
 
     # repeat to simplify after the buffer correction
-    ret_df_new = ret_df_new.map(
-        lambda x: x
-        if x is None
-        else _simplify_polys(x, minarea=0.001, tolerance=0.0001)
-    )
+    ret_df_new = ret_df_new.map(lambda x: x if x is None else _simplify_polys(
+        x, minarea=0.001, tolerance=0.0001))
     ret_df_new = ret_df_new.apply(lambda x: x if x is None else make_valid(x))
 
     # Drops empty geometry
@@ -375,9 +372,11 @@ def eez(countries, country_shapes, EEZ_gpkg, out_logging=False, distance=0.01):
     return ret_df
 
 
-def download_WorldPop(
-    country_code, year=2020, update=False, out_logging=False, size_min=300
-):
+def download_WorldPop(country_code,
+                      year=2020,
+                      update=False,
+                      out_logging=False,
+                      size_min=300):
     """
     Download tiff file for each country code
 
@@ -415,9 +414,8 @@ def download_WorldPop(
         f"https://data.worldpop.org/GIS/Population/Global_2000_2020_Constrained/2020/maxar_v1/{_two_2_three_digits_country(country_code).upper()}/{WorldPop_filename}",
     ]
 
-    WorldPop_inputfile = os.path.join(
-        os.getcwd(), "data", "raw", "WorldPop", WorldPop_filename
-    )  # Input filepath tif
+    WorldPop_inputfile = os.path.join(os.getcwd(), "data", "raw", "WorldPop",
+                                      WorldPop_filename)  # Input filepath tif
 
     if not os.path.exists(WorldPop_inputfile) or update is True:
         if out_logging:
@@ -436,7 +434,8 @@ def download_WorldPop(
                         loaded = True
                         break
         if not loaded:
-            _logger.error(f"Stage 4/4: Impossible to download {WorldPop_filename}")
+            _logger.error(
+                f"Stage 4/4: Impossible to download {WorldPop_filename}")
 
     return WorldPop_inputfile, WorldPop_filename
 
@@ -454,14 +453,12 @@ def convert_GDP(name_file_nc, year=2015, out_logging=False):
     name_file_tif = name_file_nc[:-2] + "tif"
 
     # path of the nc file
-    GDP_nc = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_nc
-    )  # Input filepath nc
+    GDP_nc = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                          name_file_nc)  # Input filepath nc
 
     # path of the tif file
-    GDP_tif = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_tif
-    )  # Input filepath nc
+    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                           name_file_tif)  # Input filepath nc
 
     # Check if file exists, otherwise throw exception
     if not os.path.exists(GDP_nc):
@@ -505,9 +502,8 @@ def load_GDP(
 
     # path of the nc file
     name_file_tif = name_file_nc[:-2] + "tif"
-    GDP_tif = os.path.join(
-        os.getcwd(), "data", "raw", "GDP", name_file_tif
-    )  # Input filepath tif
+    GDP_tif = os.path.join(os.getcwd(), "data", "raw", "GDP",
+                           name_file_tif)  # Input filepath tif
 
     if update | (not os.path.exists(GDP_tif)):
         if out_logging:
@@ -554,9 +550,11 @@ def add_gdp_data(
             #   where the border of the shape lays. This may affect the computation
             #   but it is conservative and avoids considering multiple times the same
             #   pixels
-            out_image, out_transform = generalized_mask(
-                src, row["geometry"], all_touched=True, invert=False, nodata=0.0
-            )
+            out_image, out_transform = generalized_mask(src,
+                                                        row["geometry"],
+                                                        all_touched=True,
+                                                        invert=False,
+                                                        nodata=0.0)
             # out_image_int, out_transform = mask(src,
             #                                row["geometry"],
             #                                all_touched=False,
@@ -568,21 +566,19 @@ def add_gdp_data(
             # gdp_by_geom = out_image.sum()/2 + out_image_int.sum()/2
 
             if out_logging == True:
-                _logger.info(
-                    "Stage 4/4 GDP: shape: "
-                    + str(index)
-                    + " out of "
-                    + str(df_gadm.shape[0])
-                )
+                _logger.info("Stage 4/4 GDP: shape: " + str(index) +
+                             " out of " + str(df_gadm.shape[0]))
 
             # update the gdp data in the dataset
             df_gadm.loc[index, "gdp"] = gdp_by_geom
     return df_gadm
 
 
-def add_population_data(
-    df_gadm, country_codes, year=2020, update=False, out_logging=False
-):
+def add_population_data(df_gadm,
+                        country_codes,
+                        year=2020,
+                        update=False,
+                        out_logging=False):
     """Function to add the population info for each country shape in the gadm dataset"""
 
     if out_logging:
@@ -596,8 +592,7 @@ def add_population_data(
 
     for c_code in country_codes:
         WorldPop_inputfile, WorldPop_filename = download_WorldPop(
-            c_code, year, update, out_logging
-        )
+            c_code, year, update, out_logging)
 
         with rasterio.open(WorldPop_inputfile) as src:
             country_rows = df_gadm.loc[df_gadm["country"] == c_code]
@@ -608,9 +603,11 @@ def add_population_data(
                 #   where the border of the shape lays. This leads to slightly overestimate
                 #   the population, but the error is limited and it enables halving the
                 #   computational time
-                out_image, out_transform = generalized_mask(
-                    src, row["geometry"], all_touched=True, invert=False, nodata=0.0
-                )
+                out_image, out_transform = generalized_mask(src,
+                                                            row["geometry"],
+                                                            all_touched=True,
+                                                            invert=False,
+                                                            nodata=0.0)
                 # out_image_int, out_transform = mask(src,
                 #                                row["geometry"],
                 #                                all_touched=False,
@@ -627,15 +624,8 @@ def add_population_data(
                 count += 1
 
                 if out_logging == True:
-                    _logger.info(
-                        "Stage 4/4 POP: "
-                        + str(count)
-                        + " out of "
-                        + str(df_gadm.shape[0])
-                        + " ["
-                        + c_code
-                        + "]"
-                    )
+                    _logger.info("Stage 4/4 POP: " + str(count) + " out of " +
+                                 str(df_gadm.shape[0]) + " [" + c_code + "]")
                     # print(c_code, ": ", index, " out of ",
                     #      country_rows.shape[0])
 
@@ -697,7 +687,8 @@ if __name__ == "__main__":
     country_shapes = countries(countries_list, update, out_logging)
     save_to_geojson(country_shapes, out.country_shapes)
 
-    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg, out_logging)
+    offshore_shapes = eez(countries_list, country_shapes, EEZ_gpkg,
+                          out_logging)
     save_to_geojson(offshore_shapes, out.offshore_shapes)
 
     # offshore_shapes_old = eez(countries_list, country_shapes, update, out_logging)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -157,11 +157,14 @@ def normed(x):
 def weighting_for_country(n, x):
     conv_carriers = {"OCGT", "CCGT", "PHS", "hydro"}
     gen = n.generators.loc[n.generators.carrier.isin(conv_carriers)].groupby(
-        "bus").p_nom.sum().reindex(
-            n.buses.index,
-            fill_value=0.0) + n.storage_units.loc[n.storage_units.carrier.isin(
-                conv_carriers)].groupby("bus").p_nom.sum().reindex(
-                    n.buses.index, fill_value=0.0)
+        "bus"
+    ).p_nom.sum().reindex(n.buses.index, fill_value=0.0) + n.storage_units.loc[
+        n.storage_units.carrier.isin(conv_carriers)
+    ].groupby(
+        "bus"
+    ).p_nom.sum().reindex(
+        n.buses.index, fill_value=0.0
+    )
     load = n.loads_t.p_set.mean().groupby(n.loads.bus).sum()
 
     b_i = x.index
@@ -178,8 +181,14 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     if solver_name is None:
         solver_name = snakemake.config["solving"]["solver"]["name"]
 
-    L = (n.loads_t.p_set.mean().groupby(n.loads.bus).sum().groupby(
-        [n.buses.country]).sum().pipe(normed))
+    L = (
+        n.loads_t.p_set.mean()
+        .groupby(n.loads.bus)
+        .sum()
+        .groupby([n.buses.country])
+        .sum()
+        .pipe(normed)
+    )
 
     # originally ["country", "sub_networks"]
     N = n.buses.groupby(["country"]).size()
@@ -192,20 +201,19 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
 
         total_focus = sum(list(focus_weights.values()))
 
-        assert (total_focus <= 1.0
-                ), "The sum of focus weights must be less than or equal to 1."
+        assert (
+            total_focus <= 1.0
+        ), "The sum of focus weights must be less than or equal to 1."
 
         for country, weight in focus_weights.items():
             L[country] = weight / len(L[country])
 
         remainder = [
-            c not in focus_weights.keys()
-            for c in L.index.get_level_values("country")
+            c not in focus_weights.keys() for c in L.index.get_level_values("country")
         ]
         L[remainder] = L.loc[remainder].pipe(normed) * (1 - total_focus)
 
-        logger.warning(
-            "Using custom focus weights for determining number of clusters.")
+        logger.warning("Using custom focus weights for determining number of clusters.")
 
     assert np.isclose(
         L.sum(), 1.0, rtol=1e-3
@@ -230,7 +238,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     m.n = po.Var(list(L.index), bounds=n_bounds, domain=po.Integers)
     m.tot = po.Constraint(expr=(po.summation(m.n) == n_clusters))
     m.objective = po.Objective(
-        expr=sum((m.n[i] - L.loc[i] * n_clusters)**2 for i in L.index),
+        expr=sum((m.n[i] - L.loc[i] * n_clusters) ** 2 for i in L.index),
         sense=po.minimize,
     )
 
@@ -242,18 +250,16 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
         opt = po.SolverFactory("ipopt")
 
     results = opt.solve(m)
-    assert (results["Solver"][0]["Status"] == "ok"
-            ), f"Solver returned non-optimally: {results}"
+    assert (
+        results["Solver"][0]["Status"] == "ok"
+    ), f"Solver returned non-optimally: {results}"
 
     return pd.Series(m.n.get_values(), index=L.index).astype(int)
 
 
-def busmap_for_n_clusters(n,
-                          n_clusters,
-                          solver_name,
-                          focus_weights=None,
-                          algorithm="kmeans",
-                          **algorithm_kwds):
+def busmap_for_n_clusters(
+    n, n_clusters, solver_name, focus_weights=None, algorithm="kmeans", **algorithm_kwds
+):
     if algorithm == "kmeans":
         algorithm_kwds.setdefault("n_init", 1000)
         algorithm_kwds.setdefault("max_iter", 30000)
@@ -263,17 +269,17 @@ def busmap_for_n_clusters(n,
     n.determine_network_topology()
 
     if n.buses.country.nunique() > 1:
-        n_clusters = distribute_clusters(n,
-                                         n_clusters,
-                                         focus_weights=focus_weights,
-                                         solver_name=solver_name)
+        n_clusters = distribute_clusters(
+            n, n_clusters, focus_weights=focus_weights, solver_name=solver_name
+        )
 
     def reduce_network(n, buses):
         nr = pypsa.Network()
         nr.import_components_from_dataframe(buses, "Bus")
         nr.import_components_from_dataframe(
-            n.lines.loc[n.lines.bus0.isin(buses.index)
-                        & n.lines.bus1.isin(buses.index)],
+            n.lines.loc[
+                n.lines.bus0.isin(buses.index) & n.lines.bus1.isin(buses.index)
+            ],
             "Line",
         )
         return nr
@@ -292,10 +298,12 @@ def busmap_for_n_clusters(n,
 
         if algorithm == "kmeans":
             return prefix + busmap_by_kmeans(
-                n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds)
+                n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds
+            )
         elif algorithm == "spectral":
             return prefix + busmap_by_spectral_clustering(
-                reduce_network(n, x), n_cluster_c, **algorithm_kwds)
+                reduce_network(n, x), n_cluster_c, **algorithm_kwds
+            )
         # TODO: Check where it is imported from
         # elif algorithm == "louvain":
         #     return prefix + busmap_by_louvain(reduce_network(
@@ -305,11 +313,16 @@ def busmap_for_n_clusters(n,
                 f"`algorithm` must be one of 'kmeans', 'spectral' or 'louvain'. Is {algorithm}."
             )
 
-    return (n.buses.groupby(
-        # ["country", "sub_network"], #TODO Why do we need sub_networks?
-        ["country"],
-        group_keys=False,
-    ).apply(busmap_for_country).squeeze().rename("busmap"))
+    return (
+        n.buses.groupby(
+            # ["country", "sub_network"], #TODO Why do we need sub_networks?
+            ["country"],
+            group_keys=False,
+        )
+        .apply(busmap_for_country)
+        .squeeze()
+        .rename("busmap")
+    )
 
 
 def clustering_for_n_clusters(
@@ -335,15 +348,13 @@ def clustering_for_n_clusters(
         )
 
     if custom_busmap:
-        busmap = pd.read_csv(snakemake.input.custom_busmap,
-                             index_col=0,
-                             squeeze=True)
+        busmap = pd.read_csv(snakemake.input.custom_busmap, index_col=0, squeeze=True)
         busmap.index = busmap.index.astype(str)
-        logger.info(
-            f"Imported custom busmap from {snakemake.input.custom_busmap}")
+        logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
     else:
-        busmap = busmap_for_n_clusters(n, n_clusters, solver_name,
-                                       focus_weights, algorithm)
+        busmap = busmap_for_n_clusters(
+            n, n_clusters, solver_name, focus_weights, algorithm
+        )
 
     clustering = get_clustering_from_busmap(
         n,
@@ -353,21 +364,17 @@ def clustering_for_n_clusters(
         aggregate_generators_carriers=aggregate_carriers,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=line_length_factor,
-        generator_strategies={
-            "p_nom_max": p_nom_max_strategy,
-            "p_nom_min": np.sum
-        },
+        generator_strategies={"p_nom_max": p_nom_max_strategy, "p_nom_min": np.sum},
         scale_link_capital_costs=False,
     )
 
     if not n.links.empty:
         nc = clustering.network
         nc.links["underwater_fraction"] = (
-            n.links.eval("underwater_fraction * length").div(
-                nc.links.length).dropna())
+            n.links.eval("underwater_fraction * length").div(nc.links.length).dropna()
+        )
         nc.links["capital_cost"] = nc.links["capital_cost"].add(
-            (nc.links.length -
-             n.links.length).clip(lower=0).mul(extended_link_costs),
+            (nc.links.length - n.links.length).clip(lower=0).mul(extended_link_costs),
             fill_value=0,
         )
 
@@ -391,12 +398,13 @@ def cluster_regions(busmaps, input=None, output=None):
     busmap = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
 
     for which in ("regions_onshore", "regions_offshore"):
-        regions = (gpd.read_file(getattr(input,
-                                         which)).set_index("name").dropna()
-                   )  # TODO fix the None geomerty in the regions files
+        regions = (
+            gpd.read_file(getattr(input, which)).set_index("name").dropna()
+        )  # TODO fix the None geomerty in the regions files
 
-        geom_c = (regions.geometry.groupby(busmap).apply(list).apply(
-            shapely.ops.unary_union))
+        geom_c = (
+            regions.geometry.groupby(busmap).apply(list).apply(shapely.ops.unary_union)
+        )
         regions_c = gpd.GeoDataFrame(dict(geometry=geom_c))
         regions_c.index.name = "name"
         save_to_geojson(regions_c, getattr(output, which))
@@ -418,25 +426,28 @@ if __name__ == "__main__":
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-        snakemake = mock_snakemake("cluster_network",
-                                   network="elec",
-                                   simpl="",
-                                   clusters="10")
+        snakemake = mock_snakemake(
+            "cluster_network", network="elec", simpl="", clusters="10"
+        )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 
     focus_weights = snakemake.config.get("focus_weights", None)
 
-    renewable_carriers = pd.Index([
-        tech for tech in n.generators.carrier.unique()
-        if tech in snakemake.config["renewable"]
-    ])
+    renewable_carriers = pd.Index(
+        [
+            tech
+            for tech in n.generators.carrier.unique()
+            if tech in snakemake.config["renewable"]
+        ]
+    )
 
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
-        aggregate_carriers = pd.Index(
-            n.generators.carrier.unique()).difference(renewable_carriers)
+        aggregate_carriers = pd.Index(n.generators.carrier.unique()).difference(
+            renewable_carriers
+        )
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None  # All
@@ -446,7 +457,8 @@ if __name__ == "__main__":
         busmap = n.buses.index.to_series()
         linemap = n.lines.index.to_series()
         clustering = pypsa.networkclustering.Clustering(
-            n, busmap, linemap, linemap, pd.Series(dtype="O"))
+            n, busmap, linemap, linemap, pd.Series(dtype="O")
+        )
     else:
         line_length_factor = snakemake.config["lines"]["length_factor"]
         hvac_overhead_cost = load_costs(
@@ -458,15 +470,19 @@ if __name__ == "__main__":
 
         def consense(x):
             v = x.iat[0]
-            assert (x == v).all() or x.isnull().all(
-            ), "The `potential` configuration option must agree for all renewable carriers, for now!"
+            assert (
+                x == v
+            ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
         potential_mode = consense(
-            pd.Series([
-                snakemake.config["renewable"][tech]["potential"]
-                for tech in renewable_carriers
-            ]))
+            pd.Series(
+                [
+                    snakemake.config["renewable"][tech]["potential"]
+                    for tech in renewable_carriers
+                ]
+            )
+        )
         custom_busmap = snakemake.config["enable"].get("custom_busmap", False)
         clustering = clustering_for_n_clusters(
             n,
@@ -484,9 +500,9 @@ if __name__ == "__main__":
 
     clustering.network.export_to_netcdf(snakemake.output.network)
     for attr in (
-            "busmap",
-            "linemap",
+        "busmap",
+        "linemap",
     ):  # also available: linemap_positive, linemap_negative
         getattr(clustering, attr).to_csv(snakemake.output[attr])
 
-    cluster_regions((clustering.busmap, ))
+    cluster_regions((clustering.busmap,))

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -157,11 +157,14 @@ def normed(x):
 def weighting_for_country(n, x):
     conv_carriers = {"OCGT", "CCGT", "PHS", "hydro"}
     gen = n.generators.loc[n.generators.carrier.isin(conv_carriers)].groupby(
-        "bus").p_nom.sum().reindex(
-            n.buses.index,
-            fill_value=0.0) + n.storage_units.loc[n.storage_units.carrier.isin(
-                conv_carriers)].groupby("bus").p_nom.sum().reindex(
-                    n.buses.index, fill_value=0.0)
+        "bus"
+    ).p_nom.sum().reindex(n.buses.index, fill_value=0.0) + n.storage_units.loc[
+        n.storage_units.carrier.isin(conv_carriers)
+    ].groupby(
+        "bus"
+    ).p_nom.sum().reindex(
+        n.buses.index, fill_value=0.0
+    )
     load = n.loads_t.p_set.mean().groupby(n.loads.bus).sum()
 
     b_i = x.index
@@ -178,8 +181,14 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     if solver_name is None:
         solver_name = snakemake.config["solving"]["solver"]["name"]
 
-    L = (n.loads_t.p_set.mean().groupby(n.loads.bus).sum().groupby(
-        [n.buses.country]).sum().pipe(normed))
+    L = (
+        n.loads_t.p_set.mean()
+        .groupby(n.loads.bus)
+        .sum()
+        .groupby([n.buses.country])
+        .sum()
+        .pipe(normed)
+    )
 
     # originally ["country", "sub_networks"]
     N = n.buses.groupby(["country"]).size()
@@ -192,20 +201,19 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
 
         total_focus = sum(list(focus_weights.values()))
 
-        assert (total_focus <= 1.0
-                ), "The sum of focus weights must be less than or equal to 1."
+        assert (
+            total_focus <= 1.0
+        ), "The sum of focus weights must be less than or equal to 1."
 
         for country, weight in focus_weights.items():
             L[country] = weight / len(L[country])
 
         remainder = [
-            c not in focus_weights.keys()
-            for c in L.index.get_level_values("country")
+            c not in focus_weights.keys() for c in L.index.get_level_values("country")
         ]
         L[remainder] = L.loc[remainder].pipe(normed) * (1 - total_focus)
 
-        logger.warning(
-            "Using custom focus weights for determining number of clusters.")
+        logger.warning("Using custom focus weights for determining number of clusters.")
 
     assert np.isclose(
         L.sum(), 1.0, rtol=1e-3
@@ -230,7 +238,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     m.n = po.Var(list(L.index), bounds=n_bounds, domain=po.Integers)
     m.tot = po.Constraint(expr=(po.summation(m.n) == n_clusters))
     m.objective = po.Objective(
-        expr=sum((m.n[i] - L.loc[i] * n_clusters)**2 for i in L.index),
+        expr=sum((m.n[i] - L.loc[i] * n_clusters) ** 2 for i in L.index),
         sense=po.minimize,
     )
 
@@ -242,18 +250,16 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
         opt = po.SolverFactory("ipopt")
 
     results = opt.solve(m)
-    assert (results["Solver"][0]["Status"] == "ok"
-            ), f"Solver returned non-optimally: {results}"
+    assert (
+        results["Solver"][0]["Status"] == "ok"
+    ), f"Solver returned non-optimally: {results}"
 
     return pd.Series(m.n.get_values(), index=L.index).astype(int)
 
 
-def busmap_for_n_clusters(n,
-                          n_clusters,
-                          solver_name,
-                          focus_weights=None,
-                          algorithm="kmeans",
-                          **algorithm_kwds):
+def busmap_for_n_clusters(
+    n, n_clusters, solver_name, focus_weights=None, algorithm="kmeans", **algorithm_kwds
+):
     if algorithm == "kmeans":
         algorithm_kwds.setdefault("n_init", 1000)
         algorithm_kwds.setdefault("max_iter", 30000)
@@ -263,17 +269,17 @@ def busmap_for_n_clusters(n,
     n.determine_network_topology()
 
     if n.buses.country.nunique() > 1:
-        n_clusters = distribute_clusters(n,
-                                         n_clusters,
-                                         focus_weights=focus_weights,
-                                         solver_name=solver_name)
+        n_clusters = distribute_clusters(
+            n, n_clusters, focus_weights=focus_weights, solver_name=solver_name
+        )
 
     def reduce_network(n, buses):
         nr = pypsa.Network()
         nr.import_components_from_dataframe(buses, "Bus")
         nr.import_components_from_dataframe(
-            n.lines.loc[n.lines.bus0.isin(buses.index)
-                        & n.lines.bus1.isin(buses.index)],
+            n.lines.loc[
+                n.lines.bus0.isin(buses.index) & n.lines.bus1.isin(buses.index)
+            ],
             "Line",
         )
         return nr
@@ -291,14 +297,13 @@ def busmap_for_n_clusters(n,
         weight = weighting_for_country(n, x)
 
         if algorithm == "kmeans":
-            return prefix + busmap_by_kmeans(n,
-                                             weight,
-                                             n_cluster_c,
-                                             buses_i=x.index,
-                                             **algorithm_kwds)
+            return prefix + busmap_by_kmeans(
+                n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds
+            )
         elif algorithm == "spectral":
             return prefix + busmap_by_spectral_clustering(
-                reduce_network(n, x), n_cluster_c, **algorithm_kwds)
+                reduce_network(n, x), n_cluster_c, **algorithm_kwds
+            )
         # TODO: Check where it is imported from
         # elif algorithm == "louvain":
         #     return prefix + busmap_by_louvain(reduce_network(
@@ -308,11 +313,16 @@ def busmap_for_n_clusters(n,
                 f"`algorithm` must be one of 'kmeans', 'spectral' or 'louvain'. Is {algorithm}."
             )
 
-    return (n.buses.groupby(
-        # ["country", "sub_network"], #TODO Why do we need sub_networks?
-        ["country"],
-        group_keys=False,
-    ).apply(busmap_for_country).squeeze().rename("busmap"))
+    return (
+        n.buses.groupby(
+            # ["country", "sub_network"], #TODO Why do we need sub_networks?
+            ["country"],
+            group_keys=False,
+        )
+        .apply(busmap_for_country)
+        .squeeze()
+        .rename("busmap")
+    )
 
 
 def clustering_for_n_clusters(
@@ -338,15 +348,13 @@ def clustering_for_n_clusters(
         )
 
     if custom_busmap:
-        busmap = pd.read_csv(snakemake.input.custom_busmap,
-                             index_col=0,
-                             squeeze=True)
+        busmap = pd.read_csv(snakemake.input.custom_busmap, index_col=0, squeeze=True)
         busmap.index = busmap.index.astype(str)
-        logger.info(
-            f"Imported custom busmap from {snakemake.input.custom_busmap}")
+        logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
     else:
-        busmap = busmap_for_n_clusters(n, n_clusters, solver_name,
-                                       focus_weights, algorithm)
+        busmap = busmap_for_n_clusters(
+            n, n_clusters, solver_name, focus_weights, algorithm
+        )
 
     clustering = get_clustering_from_busmap(
         n,
@@ -356,21 +364,17 @@ def clustering_for_n_clusters(
         aggregate_generators_carriers=aggregate_carriers,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=line_length_factor,
-        generator_strategies={
-            "p_nom_max": p_nom_max_strategy,
-            "p_nom_min": np.sum
-        },
+        generator_strategies={"p_nom_max": p_nom_max_strategy, "p_nom_min": np.sum},
         scale_link_capital_costs=False,
     )
 
     if not n.links.empty:
         nc = clustering.network
         nc.links["underwater_fraction"] = (
-            n.links.eval("underwater_fraction * length").div(
-                nc.links.length).dropna())
+            n.links.eval("underwater_fraction * length").div(nc.links.length).dropna()
+        )
         nc.links["capital_cost"] = nc.links["capital_cost"].add(
-            (nc.links.length -
-             n.links.length).clip(lower=0).mul(extended_link_costs),
+            (nc.links.length - n.links.length).clip(lower=0).mul(extended_link_costs),
             fill_value=0,
         )
 
@@ -394,13 +398,12 @@ def cluster_regions(busmaps, input=None, output=None):
     busmap = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
 
     for which in ("regions_onshore", "regions_offshore"):
-        regions = (gpd.read_file(getattr(input,
-                                         which)).set_index("name").dropna()
-                   )  # TODO fix the None geomerty in the regions files
+        regions = (
+            gpd.read_file(getattr(input, which)).set_index("name").dropna()
+        )  # TODO fix the None geomerty in the regions files
 
         geom_c = (
-            regions.geometry.groupby(busmap).apply(list).apply(
-                shapely.ops.unary_union)
+            regions.geometry.groupby(busmap).apply(list).apply(shapely.ops.unary_union)
         )
         regions_c = gpd.GeoDataFrame(dict(geometry=geom_c))
         regions_c.index.name = "name"
@@ -423,25 +426,28 @@ if __name__ == "__main__":
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-        snakemake = mock_snakemake("cluster_network",
-                                   network="elec",
-                                   simpl="",
-                                   clusters="10")
+        snakemake = mock_snakemake(
+            "cluster_network", network="elec", simpl="", clusters="10"
+        )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 
     focus_weights = snakemake.config.get("focus_weights", None)
 
-    renewable_carriers = pd.Index([
-        tech for tech in n.generators.carrier.unique()
-        if tech in snakemake.config["renewable"]
-    ])
+    renewable_carriers = pd.Index(
+        [
+            tech
+            for tech in n.generators.carrier.unique()
+            if tech in snakemake.config["renewable"]
+        ]
+    )
 
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
-        aggregate_carriers = pd.Index(
-            n.generators.carrier.unique()).difference(renewable_carriers)
+        aggregate_carriers = pd.Index(n.generators.carrier.unique()).difference(
+            renewable_carriers
+        )
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None  # All
@@ -451,7 +457,8 @@ if __name__ == "__main__":
         busmap = n.buses.index.to_series()
         linemap = n.lines.index.to_series()
         clustering = pypsa.networkclustering.Clustering(
-            n, busmap, linemap, linemap, pd.Series(dtype="O"))
+            n, busmap, linemap, linemap, pd.Series(dtype="O")
+        )
     else:
         line_length_factor = snakemake.config["lines"]["length_factor"]
         hvac_overhead_cost = load_costs(
@@ -463,15 +470,19 @@ if __name__ == "__main__":
 
         def consense(x):
             v = x.iat[0]
-            assert (x == v).all() or x.isnull().all(
-            ), "The `potential` configuration option must agree for all renewable carriers, for now!"
+            assert (
+                x == v
+            ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
         potential_mode = consense(
-            pd.Series([
-                snakemake.config["renewable"][tech]["potential"]
-                for tech in renewable_carriers
-            ]))
+            pd.Series(
+                [
+                    snakemake.config["renewable"][tech]["potential"]
+                    for tech in renewable_carriers
+                ]
+            )
+        )
         custom_busmap = snakemake.config["enable"].get("custom_busmap", False)
         clustering = clustering_for_n_clusters(
             n,
@@ -489,9 +500,9 @@ if __name__ == "__main__":
 
     clustering.network.export_to_netcdf(snakemake.output.network)
     for attr in (
-            "busmap",
-            "linemap",
+        "busmap",
+        "linemap",
     ):  # also available: linemap_positive, linemap_negative
         getattr(clustering, attr).to_csv(snakemake.output[attr])
 
-    cluster_regions((clustering.busmap, ))
+    cluster_regions((clustering.busmap,))

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -425,7 +425,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("cluster_network",
                                    network="elec",
                                    simpl="",
-                                   clusters="50")
+                                   clusters="10")
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -131,11 +131,14 @@ import pyomo.environ as po
 import pypsa
 import seaborn as sns
 import shapely
-from _helpers import _sets_path_to_root, configure_logging, update_p_nom_max
+from _helpers import _sets_path_to_root
+from _helpers import configure_logging
+from _helpers import update_p_nom_max
 from add_electricity import load_costs
-from pypsa.networkclustering import (_make_consense, busmap_by_kmeans,
-                                     busmap_by_spectral_clustering,
-                                     get_clustering_from_busmap)
+from pypsa.networkclustering import _make_consense
+from pypsa.networkclustering import busmap_by_kmeans
+from pypsa.networkclustering import busmap_by_spectral_clustering
+from pypsa.networkclustering import get_clustering_from_busmap
 
 idx = pd.IndexSlice
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -425,7 +425,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("cluster_network",
                                    network="elec",
                                    simpl="",
-                                   clusters="20")
+                                   clusters="50")
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -157,14 +157,11 @@ def normed(x):
 def weighting_for_country(n, x):
     conv_carriers = {"OCGT", "CCGT", "PHS", "hydro"}
     gen = n.generators.loc[n.generators.carrier.isin(conv_carriers)].groupby(
-        "bus"
-    ).p_nom.sum().reindex(n.buses.index, fill_value=0.0) + n.storage_units.loc[
-        n.storage_units.carrier.isin(conv_carriers)
-    ].groupby(
-        "bus"
-    ).p_nom.sum().reindex(
-        n.buses.index, fill_value=0.0
-    )
+        "bus").p_nom.sum().reindex(
+            n.buses.index,
+            fill_value=0.0) + n.storage_units.loc[n.storage_units.carrier.isin(
+                conv_carriers)].groupby("bus").p_nom.sum().reindex(
+                    n.buses.index, fill_value=0.0)
     load = n.loads_t.p_set.mean().groupby(n.loads.bus).sum()
 
     b_i = x.index
@@ -181,14 +178,8 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     if solver_name is None:
         solver_name = snakemake.config["solving"]["solver"]["name"]
 
-    L = (
-        n.loads_t.p_set.mean()
-        .groupby(n.loads.bus)
-        .sum()
-        .groupby([n.buses.country])
-        .sum()
-        .pipe(normed)
-    )
+    L = (n.loads_t.p_set.mean().groupby(n.loads.bus).sum().groupby(
+        [n.buses.country]).sum().pipe(normed))
 
     # originally ["country", "sub_networks"]
     N = n.buses.groupby(["country"]).size()
@@ -201,19 +192,20 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
 
         total_focus = sum(list(focus_weights.values()))
 
-        assert (
-            total_focus <= 1.0
-        ), "The sum of focus weights must be less than or equal to 1."
+        assert (total_focus <= 1.0
+                ), "The sum of focus weights must be less than or equal to 1."
 
         for country, weight in focus_weights.items():
             L[country] = weight / len(L[country])
 
         remainder = [
-            c not in focus_weights.keys() for c in L.index.get_level_values("country")
+            c not in focus_weights.keys()
+            for c in L.index.get_level_values("country")
         ]
         L[remainder] = L.loc[remainder].pipe(normed) * (1 - total_focus)
 
-        logger.warning("Using custom focus weights for determining number of clusters.")
+        logger.warning(
+            "Using custom focus weights for determining number of clusters.")
 
     assert np.isclose(
         L.sum(), 1.0, rtol=1e-3
@@ -238,7 +230,7 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     m.n = po.Var(list(L.index), bounds=n_bounds, domain=po.Integers)
     m.tot = po.Constraint(expr=(po.summation(m.n) == n_clusters))
     m.objective = po.Objective(
-        expr=sum((m.n[i] - L.loc[i] * n_clusters) ** 2 for i in L.index),
+        expr=sum((m.n[i] - L.loc[i] * n_clusters)**2 for i in L.index),
         sense=po.minimize,
     )
 
@@ -250,16 +242,18 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
         opt = po.SolverFactory("ipopt")
 
     results = opt.solve(m)
-    assert (
-        results["Solver"][0]["Status"] == "ok"
-    ), f"Solver returned non-optimally: {results}"
+    assert (results["Solver"][0]["Status"] == "ok"
+            ), f"Solver returned non-optimally: {results}"
 
     return pd.Series(m.n.get_values(), index=L.index).astype(int)
 
 
-def busmap_for_n_clusters(
-    n, n_clusters, solver_name, focus_weights=None, algorithm="kmeans", **algorithm_kwds
-):
+def busmap_for_n_clusters(n,
+                          n_clusters,
+                          solver_name,
+                          focus_weights=None,
+                          algorithm="kmeans",
+                          **algorithm_kwds):
     if algorithm == "kmeans":
         algorithm_kwds.setdefault("n_init", 1000)
         algorithm_kwds.setdefault("max_iter", 30000)
@@ -269,17 +263,17 @@ def busmap_for_n_clusters(
     n.determine_network_topology()
 
     if n.buses.country.nunique() > 1:
-        n_clusters = distribute_clusters(
-            n, n_clusters, focus_weights=focus_weights, solver_name=solver_name
-        )
+        n_clusters = distribute_clusters(n,
+                                         n_clusters,
+                                         focus_weights=focus_weights,
+                                         solver_name=solver_name)
 
     def reduce_network(n, buses):
         nr = pypsa.Network()
         nr.import_components_from_dataframe(buses, "Bus")
         nr.import_components_from_dataframe(
-            n.lines.loc[
-                n.lines.bus0.isin(buses.index) & n.lines.bus1.isin(buses.index)
-            ],
+            n.lines.loc[n.lines.bus0.isin(buses.index)
+                        & n.lines.bus1.isin(buses.index)],
             "Line",
         )
         return nr
@@ -298,12 +292,10 @@ def busmap_for_n_clusters(
 
         if algorithm == "kmeans":
             return prefix + busmap_by_kmeans(
-                n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds
-            )
+                n, weight, n_cluster_c, buses_i=x.index, **algorithm_kwds)
         elif algorithm == "spectral":
             return prefix + busmap_by_spectral_clustering(
-                reduce_network(n, x), n_cluster_c, **algorithm_kwds
-            )
+                reduce_network(n, x), n_cluster_c, **algorithm_kwds)
         # TODO: Check where it is imported from
         # elif algorithm == "louvain":
         #     return prefix + busmap_by_louvain(reduce_network(
@@ -313,16 +305,11 @@ def busmap_for_n_clusters(
                 f"`algorithm` must be one of 'kmeans', 'spectral' or 'louvain'. Is {algorithm}."
             )
 
-    return (
-        n.buses.groupby(
-            # ["country", "sub_network"], #TODO Why do we need sub_networks?
-            ["country"],
-            group_keys=False,
-        )
-        .apply(busmap_for_country)
-        .squeeze()
-        .rename("busmap")
-    )
+    return (n.buses.groupby(
+        # ["country", "sub_network"], #TODO Why do we need sub_networks?
+        ["country"],
+        group_keys=False,
+    ).apply(busmap_for_country).squeeze().rename("busmap"))
 
 
 def clustering_for_n_clusters(
@@ -348,13 +335,15 @@ def clustering_for_n_clusters(
         )
 
     if custom_busmap:
-        busmap = pd.read_csv(snakemake.input.custom_busmap, index_col=0, squeeze=True)
+        busmap = pd.read_csv(snakemake.input.custom_busmap,
+                             index_col=0,
+                             squeeze=True)
         busmap.index = busmap.index.astype(str)
-        logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
+        logger.info(
+            f"Imported custom busmap from {snakemake.input.custom_busmap}")
     else:
-        busmap = busmap_for_n_clusters(
-            n, n_clusters, solver_name, focus_weights, algorithm
-        )
+        busmap = busmap_for_n_clusters(n, n_clusters, solver_name,
+                                       focus_weights, algorithm)
 
     clustering = get_clustering_from_busmap(
         n,
@@ -364,17 +353,21 @@ def clustering_for_n_clusters(
         aggregate_generators_carriers=aggregate_carriers,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=line_length_factor,
-        generator_strategies={"p_nom_max": p_nom_max_strategy, "p_nom_min": np.sum},
+        generator_strategies={
+            "p_nom_max": p_nom_max_strategy,
+            "p_nom_min": np.sum
+        },
         scale_link_capital_costs=False,
     )
 
     if not n.links.empty:
         nc = clustering.network
         nc.links["underwater_fraction"] = (
-            n.links.eval("underwater_fraction * length").div(nc.links.length).dropna()
-        )
+            n.links.eval("underwater_fraction * length").div(
+                nc.links.length).dropna())
         nc.links["capital_cost"] = nc.links["capital_cost"].add(
-            (nc.links.length - n.links.length).clip(lower=0).mul(extended_link_costs),
+            (nc.links.length -
+             n.links.length).clip(lower=0).mul(extended_link_costs),
             fill_value=0,
         )
 
@@ -398,13 +391,12 @@ def cluster_regions(busmaps, input=None, output=None):
     busmap = reduce(lambda x, y: x.map(y), busmaps[1:], busmaps[0])
 
     for which in ("regions_onshore", "regions_offshore"):
-        regions = (
-            gpd.read_file(getattr(input, which)).set_index("name").dropna()
-        )  # TODO fix the None geomerty in the regions files
+        regions = (gpd.read_file(getattr(input,
+                                         which)).set_index("name").dropna()
+                   )  # TODO fix the None geomerty in the regions files
 
-        geom_c = (
-            regions.geometry.groupby(busmap).apply(list).apply(shapely.ops.unary_union)
-        )
+        geom_c = (regions.geometry.groupby(busmap).apply(list).apply(
+            shapely.ops.unary_union))
         regions_c = gpd.GeoDataFrame(dict(geometry=geom_c))
         regions_c.index.name = "name"
         save_to_geojson(regions_c, getattr(output, which))
@@ -426,28 +418,25 @@ if __name__ == "__main__":
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-        snakemake = mock_snakemake(
-            "cluster_network", network="elec", simpl="", clusters="10"
-        )
+        snakemake = mock_snakemake("cluster_network",
+                                   network="elec",
+                                   simpl="",
+                                   clusters="10")
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
 
     focus_weights = snakemake.config.get("focus_weights", None)
 
-    renewable_carriers = pd.Index(
-        [
-            tech
-            for tech in n.generators.carrier.unique()
-            if tech in snakemake.config["renewable"]
-        ]
-    )
+    renewable_carriers = pd.Index([
+        tech for tech in n.generators.carrier.unique()
+        if tech in snakemake.config["renewable"]
+    ])
 
     if snakemake.wildcards.clusters.endswith("m"):
         n_clusters = int(snakemake.wildcards.clusters[:-1])
-        aggregate_carriers = pd.Index(n.generators.carrier.unique()).difference(
-            renewable_carriers
-        )
+        aggregate_carriers = pd.Index(
+            n.generators.carrier.unique()).difference(renewable_carriers)
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None  # All
@@ -457,8 +446,7 @@ if __name__ == "__main__":
         busmap = n.buses.index.to_series()
         linemap = n.lines.index.to_series()
         clustering = pypsa.networkclustering.Clustering(
-            n, busmap, linemap, linemap, pd.Series(dtype="O")
-        )
+            n, busmap, linemap, linemap, pd.Series(dtype="O"))
     else:
         line_length_factor = snakemake.config["lines"]["length_factor"]
         hvac_overhead_cost = load_costs(
@@ -470,19 +458,15 @@ if __name__ == "__main__":
 
         def consense(x):
             v = x.iat[0]
-            assert (
-                x == v
-            ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
+            assert (x == v).all() or x.isnull().all(
+            ), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
         potential_mode = consense(
-            pd.Series(
-                [
-                    snakemake.config["renewable"][tech]["potential"]
-                    for tech in renewable_carriers
-                ]
-            )
-        )
+            pd.Series([
+                snakemake.config["renewable"][tech]["potential"]
+                for tech in renewable_carriers
+            ]))
         custom_busmap = snakemake.config["enable"].get("custom_busmap", False)
         clustering = clustering_for_n_clusters(
             n,
@@ -500,9 +484,9 @@ if __name__ == "__main__":
 
     clustering.network.export_to_netcdf(snakemake.output.network)
     for attr in (
-        "busmap",
-        "linemap",
+            "busmap",
+            "linemap",
     ):  # also available: linemap_positive, linemap_negative
         getattr(clustering, attr).to_csv(snakemake.output[attr])
 
-    cluster_regions((clustering.busmap,))
+    cluster_regions((clustering.busmap, ))

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -131,14 +131,11 @@ import pyomo.environ as po
 import pypsa
 import seaborn as sns
 import shapely
-from _helpers import configure_logging
-from _helpers import update_p_nom_max
-from _helpers import _sets_path_to_root
+from _helpers import _sets_path_to_root, configure_logging, update_p_nom_max
 from add_electricity import load_costs
-from pypsa.networkclustering import _make_consense
-from pypsa.networkclustering import busmap_by_kmeans
-from pypsa.networkclustering import busmap_by_spectral_clustering
-from pypsa.networkclustering import get_clustering_from_busmap
+from pypsa.networkclustering import (_make_consense, busmap_by_kmeans,
+                                     busmap_by_spectral_clustering,
+                                     get_clustering_from_busmap)
 
 idx = pd.IndexSlice
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -181,7 +181,8 @@ def distribute_clusters(n, n_clusters, focus_weights=None, solver_name=None):
     L = (n.loads_t.p_set.mean().groupby(n.loads.bus).sum().groupby(
         [n.buses.country]).sum().pipe(normed))
 
-    N = n.buses.groupby(["country"]).size()  # originally ["country", "sub_networks"]
+    # originally ["country", "sub_networks"]
+    N = n.buses.groupby(["country"]).size()
 
     assert (
         n_clusters >= len(N) and n_clusters <= N.sum()
@@ -419,7 +420,7 @@ def cluster_regions(busmaps, input=None, output=None):
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
-        
+
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
         snakemake = mock_snakemake("cluster_network",

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -131,14 +131,11 @@ import pyomo.environ as po
 import pypsa
 import seaborn as sns
 import shapely
-from _helpers import _sets_path_to_root
-from _helpers import configure_logging
-from _helpers import update_p_nom_max
+from _helpers import _sets_path_to_root, configure_logging, update_p_nom_max
 from add_electricity import load_costs
-from pypsa.networkclustering import _make_consense
-from pypsa.networkclustering import busmap_by_kmeans
-from pypsa.networkclustering import busmap_by_spectral_clustering
-from pypsa.networkclustering import get_clustering_from_busmap
+from pypsa.networkclustering import (_make_consense, busmap_by_kmeans,
+                                     busmap_by_spectral_clustering,
+                                     get_clustering_from_busmap)
 
 idx = pd.IndexSlice
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -425,7 +425,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("cluster_network",
                                    network="elec",
                                    simpl="",
-                                   clusters="50")
+                                   clusters="20")
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -2,16 +2,12 @@ import logging
 import math
 import os
 import sys
-from shapely.geometry import Point
-from shapely.geometry import LineString
-from shapely.ops import unary_union
-from shapely.ops import linemerge
 
 import geopandas as gpd
 import numpy as np
-from _helpers import _sets_path_to_root
-from _helpers import _to_csv_nafix
-from _helpers import configure_logging
+from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
+from shapely.geometry import LineString, Point
+from shapely.ops import linemerge, unary_union
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -23,18 +23,20 @@ def line_endings_to_bus_conversion(lines):
     # Assign to every line a start and end point
 
     lines["bounds"] = lines["geometry"].boundary  # create start and end point
-    lines["bus_0_coors"] = lines["bounds"].map(
-        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
-    )
-    lines["bus_1_coors"] = lines["bounds"].map(
-        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
-    )
+    lines["bus_0_coors"] = lines["bounds"].map(lambda p: p.geoms[0]
+                                               if len(p.geoms) >= 2 else None)
+    lines["bus_1_coors"] = lines["bounds"].map(lambda p: p.geoms[1]
+                                               if len(p.geoms) >= 2 else None)
 
     # splits into coordinates
-    lines["bus0_lon"] = lines["bus_0_coors"].map(lambda p: p.x if p != None else None)
-    lines["bus0_lat"] = lines["bus_0_coors"].map(lambda p: p.y if p != None else None)
-    lines["bus1_lon"] = lines["bus_1_coors"].map(lambda p: p.x if p != None else None)
-    lines["bus1_lat"] = lines["bus_1_coors"].map(lambda p: p.y if p != None else None)
+    lines["bus0_lon"] = lines["bus_0_coors"].map(lambda p: p.x
+                                                 if p != None else None)
+    lines["bus0_lat"] = lines["bus_0_coors"].map(lambda p: p.y
+                                                 if p != None else None)
+    lines["bus1_lon"] = lines["bus_1_coors"].map(lambda p: p.x
+                                                 if p != None else None)
+    lines["bus1_lat"] = lines["bus_1_coors"].map(lambda p: p.y
+                                                 if p != None else None)
 
     return lines
 
@@ -45,12 +47,12 @@ def create_bus_df_from_lines(substations, lines):
     bus_e = gpd.GeoDataFrame(columns=substations.columns)
 
     # Read information from line.csv
-    bus_s[["voltage", "lon", "lat", "geometry", "country"]] = lines[
-        ["voltage", "bus0_lon", "bus0_lat", "bus_0_coors", "country"]
-    ]  # line start points
-    bus_e[["voltage", "lon", "lat", "geometry", "country"]] = lines[
-        ["voltage", "bus1_lon", "bus1_lat", "bus_1_coors", "country"]
-    ]  # line end points
+    bus_s[["voltage", "lon", "lat", "geometry", "country"]] = lines[[
+        "voltage", "bus0_lon", "bus0_lat", "bus_0_coors", "country"
+    ]]  # line start points
+    bus_e[["voltage", "lon", "lat", "geometry", "country"]] = lines[[
+        "voltage", "bus1_lon", "bus1_lat", "bus_1_coors", "country"
+    ]]  # line end points
     bus_all = bus_s.append(bus_e).reset_index(drop=True)
 
     # Assign index to bus_id
@@ -74,18 +76,18 @@ def add_line_endings_tosubstations(substations, lines):
     bus_e = gpd.GeoDataFrame(columns=substations.columns)
 
     # Read information from line.csv
-    bus_s[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
+    bus_s[["voltage", "country"]] = lines[["voltage",
+                                           "country"]]  # line start points
     bus_s["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
-    )
+        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None)
     bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
     bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_s["bus_id"] = lines["line_id"].astype(str) + "_s"
 
-    bus_e[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
+    bus_e[["voltage", "country"]] = lines[["voltage",
+                                           "country"]]  # line start points
     bus_e["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
-    )
+        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None)
     bus_e["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
     bus_e["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = lines["line_id"].astype(str) + "_e"
@@ -137,11 +139,10 @@ def set_substations_ids(buses, tol=0.02):
         # get substations within tolerance
         close_nodes = np.where(
             buses.apply(
-                lambda x: math.dist([row["lat"], row["lon"]], [x["lat"], x["lon"]])
-                <= tol,
+                lambda x: math.dist([row["lat"], row["lon"]],
+                                    [x["lat"], x["lon"]]) <= tol,
                 axis=1,
-            )
-        )[0]
+            ))[0]
 
         if len(close_nodes) == 1:
             # if only one substation is in tolerance, then the substation is the current one iì
@@ -154,7 +155,8 @@ def set_substations_ids(buses, tol=0.02):
             # several substations in tolerance
 
             # get their ids
-            subset_substation_ids = buses.loc[buses.index[close_nodes], "station_id"]
+            subset_substation_ids = buses.loc[buses.index[close_nodes],
+                                              "station_id"]
             # check if all substation_ids are negative (<0)
             all_neg = subset_substation_ids.max() < 0
             # check if at least a substation_id is negative (<0)
@@ -196,35 +198,31 @@ def set_lines_ids(lines, buses):
         lines.loc[i, "bus0"] = buses.loc[bus0_id, "bus_id"]
 
         # check if the line starts exactly in the node, otherwise modify the linestring
-        distance_bus0 = buses_sel.geometry[bus0_id].distance(row["bus_0_coors"])
+        distance_bus0 = buses_sel.geometry[bus0_id].distance(
+            row["bus_0_coors"])
         if distance_bus0 > 0.0:
             # the line does not start in the node, thus modify the linestring
-            lines.loc[i, "geometry"] = linemerge(
-                [
-                    LineString(
-                        [
-                            buses_sel.geometry[bus0_id],
-                            row["bus_0_coors"],
-                        ]
-                    ),
-                    lines.loc[i, "geometry"],
-                ]
-            )
+            lines.loc[i, "geometry"] = linemerge([
+                LineString([
+                    buses_sel.geometry[bus0_id],
+                    row["bus_0_coors"],
+                ]),
+                lines.loc[i, "geometry"],
+            ])
 
         # find the closest node of the bus1 of the line
         bus1_id = buses_sel.geometry.distance(row["bus_1_coors"]).idxmin()
         lines.loc[i, "bus1"] = buses.loc[bus1_id, "bus_id"]
 
         # check if the line ends exactly in the node, otherwise modify the linestring
-        distance_bus1 = buses_sel.geometry[bus1_id].distance(row["bus_1_coors"])
+        distance_bus1 = buses_sel.geometry[bus1_id].distance(
+            row["bus_1_coors"])
         if distance_bus1 > 0.0:
             # the line does not end in the node, thus modify the linestring
-            lines.loc[i, "geometry"] = linemerge(
-                [
-                    lines.loc[i, "geometry"],
-                    LineString([row["bus_1_coors"], buses_sel.geometry[bus1_id]]),
-                ]
-            )
+            lines.loc[i, "geometry"] = linemerge([
+                lines.loc[i, "geometry"],
+                LineString([row["bus_1_coors"], buses_sel.geometry[bus1_id]]),
+            ])
 
     # update line endings
     lines = line_endings_to_bus_conversion(lines)
@@ -257,18 +255,30 @@ def merge_stations_same_station_id(buses, delta_lon=0.001, delta_lat=0.001):
 
             # add the bus
             buses_clean.loc[n_buses] = {
-                "bus_id": n_buses,
-                "station_id": g_name,
-                "voltage": v_name,
-                "dc": bus_row["dc"].all(),
-                "symbol": "|".join(bus_row["symbol"].unique()),
-                "under_construction": bus_row["under_construction"].any(),
-                "tag_substation": "|".join(bus_row["tag_substation"].unique()),
-                "tag_area": bus_row["tag_area"].sum(),
-                "lon": station_loc.lon + v_it * delta_lon,
-                "lat": station_loc.lat + v_it * delta_lat,
-                "country": bus_row["country"].iloc[0],
-                "geometry": Point(
+                "bus_id":
+                n_buses,
+                "station_id":
+                g_name,
+                "voltage":
+                v_name,
+                "dc":
+                bus_row["dc"].all(),
+                "symbol":
+                "|".join(bus_row["symbol"].unique()),
+                "under_construction":
+                bus_row["under_construction"].any(),
+                "tag_substation":
+                "|".join(bus_row["tag_substation"].unique()),
+                "tag_area":
+                bus_row["tag_area"].sum(),
+                "lon":
+                station_loc.lon + v_it * delta_lon,
+                "lat":
+                station_loc.lat + v_it * delta_lat,
+                "country":
+                bus_row["country"].iloc[0],
+                "geometry":
+                Point(
                     station_loc.lon + v_it * delta_lon,
                     station_loc.lat + v_it * delta_lat,
                 ),
@@ -288,9 +298,8 @@ def get_transformers(buses, lines):
 
     df_transformers = gpd.GeoDataFrame(columns=lines.columns)
 
-    for g_name, g_value in buses.sort_values("voltage", ascending=True).groupby(
-        by=["station_id"]
-    ):
+    for g_name, g_value in buses.sort_values(
+            "voltage", ascending=True).groupby(by=["station_id"]):
 
         # note: by construction there cannot be more that two nodes with the same station_id and same voltage
         n_voltages = len(g_value)
@@ -300,8 +309,7 @@ def get_transformers(buses, lines):
             for id in range(0, n_voltages - 1):
                 # when g_value has more than one node, it means that there are multiple voltages for the same bus
                 geom_trans = LineString(
-                    [g_value.geometry.iloc[id], g_value.geometry.iloc[id + 1]]
-                )
+                    [g_value.geometry.iloc[id], g_value.geometry.iloc[id + 1]])
                 transf_id = lines.shape[0] + df_transformers.shape[0] + 1
 
                 df_transformers.loc[transf_id] = {
@@ -347,42 +355,35 @@ def connect_stations_same_station_id(lines, buses):
 
         if len(buses_station_id) > 1:
             for b_it in range(1, len(buses_station_id)):
-                add_lines.append(
-                    [
-                        f"link{buses_station_id}_{b_it}",
-                        buses_station_id.index[0],
-                        buses_station_id.index[b_it],
-                        400000,
-                        1,
-                        0.0,
-                        False,
-                        False,
-                        "transmission",
-                        50,
-                        buses_station_id.country.iloc[0],
-                        LineString(
-                            [
-                                buses_station_id.geometry.iloc[0],
-                                buses_station_id.geometry.iloc[b_it],
-                            ]
-                        ),
-                        LineString(
-                            [
-                                buses_station_id.geometry.iloc[0],
-                                buses_station_id.geometry.iloc[b_it],
-                            ]
-                        ).bounds,
+                add_lines.append([
+                    f"link{buses_station_id}_{b_it}",
+                    buses_station_id.index[0],
+                    buses_station_id.index[b_it],
+                    400000,
+                    1,
+                    0.0,
+                    False,
+                    False,
+                    "transmission",
+                    50,
+                    buses_station_id.country.iloc[0],
+                    LineString([
                         buses_station_id.geometry.iloc[0],
                         buses_station_id.geometry.iloc[b_it],
-                        buses_station_id.lon.iloc[0],
-                        buses_station_id.lat.iloc[0],
-                        buses_station_id.lon.iloc[b_it],
-                        buses_station_id.lat.iloc[b_it],
-                    ]
-                )
-    return lines.append(
-        gpd.GeoDataFrame(add_lines, columns=lines.keys()), ignore_index=True
-    )
+                    ]),
+                    LineString([
+                        buses_station_id.geometry.iloc[0],
+                        buses_station_id.geometry.iloc[b_it],
+                    ]).bounds,
+                    buses_station_id.geometry.iloc[0],
+                    buses_station_id.geometry.iloc[b_it],
+                    buses_station_id.lon.iloc[0],
+                    buses_station_id.lat.iloc[0],
+                    buses_station_id.lon.iloc[b_it],
+                    buses_station_id.lat.iloc[b_it],
+                ])
+    return lines.append(gpd.GeoDataFrame(add_lines, columns=lines.keys()),
+                        ignore_index=True)
 
 
 def set_lv_substations(buses):
@@ -396,14 +397,11 @@ def set_lv_substations(buses):
     buses["substation_lv"] = True
 
     # For each station number with multiple buses make lowest voltage `substation_lv = TRUE`
-    bus_with_stations_duplicates = buses[
-        buses.station_id.duplicated(keep=False)
-    ].sort_values(by=["station_id", "voltage"])
-    lv_bus_at_station_duplicates = (
-        buses[buses.station_id.duplicated(keep=False)]
-        .sort_values(by=["station_id", "voltage"])
-        .drop_duplicates(subset=["station_id"])
-    )
+    bus_with_stations_duplicates = buses[buses.station_id.duplicated(
+        keep=False)].sort_values(by=["station_id", "voltage"])
+    lv_bus_at_station_duplicates = (buses[buses.station_id.duplicated(
+        keep=False)].sort_values(by=["station_id", "voltage"]).drop_duplicates(
+            subset=["station_id"]))
     # Set all buses with station duplicates "False"
     buses.loc[bus_with_stations_duplicates.index, "substation_lv"] = False
     # Set lv_buses with station duplicates "True"
@@ -494,9 +492,11 @@ def create_station_at_equal_bus_locations(lines, buses, tol=0.01):
 
 def built_network(inputs, outputs):
     # ----------- LOAD DATA -----------
-    substations = gpd.read_file(inputs["substations"]).set_crs(epsg=4326, inplace=True)
+    substations = gpd.read_file(inputs["substations"]).set_crs(epsg=4326,
+                                                               inplace=True)
     lines = gpd.read_file(inputs["lines"]).set_crs(epsg=4326, inplace=True)
-    generators = gpd.read_file(inputs["generators"]).set_crs(epsg=4326, inplace=True)
+    generators = gpd.read_file(inputs["generators"]).set_crs(epsg=4326,
+                                                             inplace=True)
 
     # Filter only Nigeria
     # lines = lines[lines.loc[:,"country"] == "nigeria"].copy()
@@ -516,9 +516,9 @@ def built_network(inputs, outputs):
     # TODO: Add and test other method (ready in jupyter)
 
     # METHOD to merge buses with same voltage and within tolerance
-    lines, buses = merge_stations_lines_by_station_id_and_voltage(
-        lines, buses, tol=0.05
-    )
+    lines, buses = merge_stations_lines_by_station_id_and_voltage(lines,
+                                                                  buses,
+                                                                  tol=0.05)
 
     # Export data
     # Lines

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -23,20 +23,18 @@ def line_endings_to_bus_conversion(lines):
     # Assign to every line a start and end point
 
     lines["bounds"] = lines["geometry"].boundary  # create start and end point
-    lines["bus_0_coors"] = lines["bounds"].map(lambda p: p.geoms[0]
-                                               if len(p.geoms) >= 2 else None)
-    lines["bus_1_coors"] = lines["bounds"].map(lambda p: p.geoms[1]
-                                               if len(p.geoms) >= 2 else None)
+    lines["bus_0_coors"] = lines["bounds"].map(
+        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
+    )
+    lines["bus_1_coors"] = lines["bounds"].map(
+        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
+    )
 
     # splits into coordinates
-    lines["bus0_lon"] = lines["bus_0_coors"].map(lambda p: p.x
-                                                 if p != None else None)
-    lines["bus0_lat"] = lines["bus_0_coors"].map(lambda p: p.y
-                                                 if p != None else None)
-    lines["bus1_lon"] = lines["bus_1_coors"].map(lambda p: p.x
-                                                 if p != None else None)
-    lines["bus1_lat"] = lines["bus_1_coors"].map(lambda p: p.y
-                                                 if p != None else None)
+    lines["bus0_lon"] = lines["bus_0_coors"].map(lambda p: p.x if p != None else None)
+    lines["bus0_lat"] = lines["bus_0_coors"].map(lambda p: p.y if p != None else None)
+    lines["bus1_lon"] = lines["bus_1_coors"].map(lambda p: p.x if p != None else None)
+    lines["bus1_lat"] = lines["bus_1_coors"].map(lambda p: p.y if p != None else None)
 
     return lines
 
@@ -47,12 +45,12 @@ def create_bus_df_from_lines(substations, lines):
     bus_e = gpd.GeoDataFrame(columns=substations.columns)
 
     # Read information from line.csv
-    bus_s[["voltage", "lon", "lat", "geometry", "country"]] = lines[[
-        "voltage", "bus0_lon", "bus0_lat", "bus_0_coors", "country"
-    ]]  # line start points
-    bus_e[["voltage", "lon", "lat", "geometry", "country"]] = lines[[
-        "voltage", "bus1_lon", "bus1_lat", "bus_1_coors", "country"
-    ]]  # line end points
+    bus_s[["voltage", "lon", "lat", "geometry", "country"]] = lines[
+        ["voltage", "bus0_lon", "bus0_lat", "bus_0_coors", "country"]
+    ]  # line start points
+    bus_e[["voltage", "lon", "lat", "geometry", "country"]] = lines[
+        ["voltage", "bus1_lon", "bus1_lat", "bus_1_coors", "country"]
+    ]  # line end points
     bus_all = bus_s.append(bus_e).reset_index(drop=True)
 
     # Assign index to bus_id
@@ -76,24 +74,20 @@ def add_line_endings_tosubstations(substations, lines):
     bus_e = gpd.GeoDataFrame(columns=substations.columns)
 
     # Read information from line.csv
-    bus_s[["voltage", "country"]] = lines[[
-        "voltage", "country"]]  # line start points
-    bus_s["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[0]
-                                                    if len(p.geoms) >= 2 else None)
-    bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x
-                                         if p != None else None)
-    bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y
-                                         if p != None else None)
+    bus_s[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
+    bus_s["geometry"] = lines.geometry.boundary.map(
+        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
+    )
+    bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
+    bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_s["bus_id"] = lines["line_id"].astype(str) + "_s"
 
-    bus_e[["voltage", "country"]] = lines[[
-        "voltage", "country"]]  # line start points
-    bus_e["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[1]
-                                                    if len(p.geoms) >= 2 else None)
-    bus_e["lon"] = bus_s["geometry"].map(lambda p: p.x
-                                         if p != None else None)
-    bus_e["lat"] = bus_s["geometry"].map(lambda p: p.y
-                                         if p != None else None)
+    bus_e[["voltage", "country"]] = lines[["voltage", "country"]]  # line start points
+    bus_e["geometry"] = lines.geometry.boundary.map(
+        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
+    )
+    bus_e["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
+    bus_e["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = lines["line_id"].astype(str) + "_e"
 
     bus_all = bus_s.append(bus_e).reset_index(drop=True)
@@ -143,10 +137,11 @@ def set_substations_ids(buses, tol=0.02):
         # get substations within tolerance
         close_nodes = np.where(
             buses.apply(
-                lambda x: math.dist([row["lat"], row["lon"]],
-                                    [x["lat"], x["lon"]]) <= tol,
+                lambda x: math.dist([row["lat"], row["lon"]], [x["lat"], x["lon"]])
+                <= tol,
                 axis=1,
-            ))[0]
+            )
+        )[0]
 
         if len(close_nodes) == 1:
             # if only one substation is in tolerance, then the substation is the current one iì
@@ -159,8 +154,7 @@ def set_substations_ids(buses, tol=0.02):
             # several substations in tolerance
 
             # get their ids
-            subset_substation_ids = buses.loc[buses.index[close_nodes],
-                                              "station_id"]
+            subset_substation_ids = buses.loc[buses.index[close_nodes], "station_id"]
             # check if all substation_ids are negative (<0)
             all_neg = subset_substation_ids.max() < 0
             # check if at least a substation_id is negative (<0)
@@ -202,34 +196,35 @@ def set_lines_ids(lines, buses):
         lines.loc[i, "bus0"] = buses.loc[bus0_id, "bus_id"]
 
         # check if the line starts exactly in the node, otherwise modify the linestring
-        distance_bus0 = buses_sel.geometry[bus0_id].distance(
-            row["bus_0_coors"])
+        distance_bus0 = buses_sel.geometry[bus0_id].distance(row["bus_0_coors"])
         if distance_bus0 > 0.0:
             # the line does not start in the node, thus modify the linestring
-            lines.loc[i, "geometry"] = linemerge([
-                LineString([
-                    buses_sel.geometry[bus0_id],
-                    row["bus_0_coors"],
-                ]),
-                lines.loc[i, "geometry"]
-            ])
+            lines.loc[i, "geometry"] = linemerge(
+                [
+                    LineString(
+                        [
+                            buses_sel.geometry[bus0_id],
+                            row["bus_0_coors"],
+                        ]
+                    ),
+                    lines.loc[i, "geometry"],
+                ]
+            )
 
         # find the closest node of the bus1 of the line
         bus1_id = buses_sel.geometry.distance(row["bus_1_coors"]).idxmin()
         lines.loc[i, "bus1"] = buses.loc[bus1_id, "bus_id"]
 
         # check if the line ends exactly in the node, otherwise modify the linestring
-        distance_bus1 = buses_sel.geometry[bus1_id].distance(
-            row["bus_1_coors"])
+        distance_bus1 = buses_sel.geometry[bus1_id].distance(row["bus_1_coors"])
         if distance_bus1 > 0.0:
             # the line does not end in the node, thus modify the linestring
-            lines.loc[i, "geometry"] = linemerge([
-                lines.loc[i, "geometry"],
-                LineString([
-                    row["bus_1_coors"],
-                    buses_sel.geometry[bus1_id]
-                ])
-            ])
+            lines.loc[i, "geometry"] = linemerge(
+                [
+                    lines.loc[i, "geometry"],
+                    LineString([row["bus_1_coors"], buses_sel.geometry[bus1_id]]),
+                ]
+            )
 
     # update line endings
     lines = line_endings_to_bus_conversion(lines)
@@ -241,7 +236,7 @@ def merge_stations_same_station_id(buses, delta_lon=0.001, delta_lat=0.001):
     """
     Function to merge buses with same voltage and station_id
     This function iterattes over all substation ids and creates a bus_id for every substation and voltage level.
-    Therefore, a substation with multiple voltage levels is represented with different buses, one per voltage level    
+    Therefore, a substation with multiple voltage levels is represented with different buses, one per voltage level
     """
     # initialize empty dataset of cleaned buses
     buses_clean = gpd.GeoDataFrame(columns=buses.columns)
@@ -275,8 +270,8 @@ def merge_stations_same_station_id(buses, delta_lon=0.001, delta_lat=0.001):
                 "country": bus_row["country"].iloc[0],
                 "geometry": Point(
                     station_loc.lon + v_it * delta_lon,
-                    station_loc.lat + v_it * delta_lat
-                )
+                    station_loc.lat + v_it * delta_lat,
+                ),
             }
 
             # increase counters
@@ -293,41 +288,42 @@ def get_transformers(buses, lines):
 
     df_transformers = gpd.GeoDataFrame(columns=lines.columns)
 
-    for g_name, g_value in buses.sort_values('voltage', ascending=True).groupby(by=['station_id']):
+    for g_name, g_value in buses.sort_values("voltage", ascending=True).groupby(
+        by=["station_id"]
+    ):
 
         # note: by construction there cannot be more that two nodes with the same station_id and same voltage
         n_voltages = len(g_value)
 
         if n_voltages > 1:
 
-            for id in range(0, n_voltages-1):
+            for id in range(0, n_voltages - 1):
                 # when g_value has more than one node, it means that there are multiple voltages for the same bus
-                geom_trans = LineString([
-                    g_value.geometry.iloc[id],
-                    g_value.geometry.iloc[id+1]
-                ])
+                geom_trans = LineString(
+                    [g_value.geometry.iloc[id], g_value.geometry.iloc[id + 1]]
+                )
                 transf_id = lines.shape[0] + df_transformers.shape[0] + 1
 
                 df_transformers.loc[transf_id] = {
-                    'line_id': f"transf_{g_name}_{id}",
-                    'bus0': g_value['bus_id'].iloc[id],
-                    'bus1': g_value['bus_id'].iloc[id+1],
-                    'voltage': g_value.voltage.iloc[[id, id+1]].max(),
-                    'circuits': 1,
-                    'length': 0.0,
-                    'underground': False,
-                    'under_construction': False,
-                    'tag_type': 'transmission',
-                    'tag_frequency': 50,
-                    'country': g_value.country.iloc[id],
-                    'geometry': geom_trans,
-                    'bounds': geom_trans.bounds,
-                    'bus_0_coors': g_value.geometry.iloc[id],
-                    'bus_1_coors': g_value.geometry.iloc[id+1],
-                    'bus0_lon': g_value.geometry.iloc[id].x,
-                    'bus0_lat': g_value.geometry.iloc[id].y,
-                    'bus1_lon': g_value.geometry.iloc[id+1].x,
-                    'bus1_lat': g_value.geometry.iloc[id+1].y,
+                    "line_id": f"transf_{g_name}_{id}",
+                    "bus0": g_value["bus_id"].iloc[id],
+                    "bus1": g_value["bus_id"].iloc[id + 1],
+                    "voltage": g_value.voltage.iloc[[id, id + 1]].max(),
+                    "circuits": 1,
+                    "length": 0.0,
+                    "underground": False,
+                    "under_construction": False,
+                    "tag_type": "transmission",
+                    "tag_frequency": 50,
+                    "country": g_value.country.iloc[id],
+                    "geometry": geom_trans,
+                    "bounds": geom_trans.bounds,
+                    "bus_0_coors": g_value.geometry.iloc[id],
+                    "bus_1_coors": g_value.geometry.iloc[id + 1],
+                    "bus0_lon": g_value.geometry.iloc[id].x,
+                    "bus0_lat": g_value.geometry.iloc[id].y,
+                    "bus1_lon": g_value.geometry.iloc[id + 1].x,
+                    "bus1_lat": g_value.geometry.iloc[id + 1].y,
                 }
 
     # update line endings
@@ -351,35 +347,42 @@ def connect_stations_same_station_id(lines, buses):
 
         if len(buses_station_id) > 1:
             for b_it in range(1, len(buses_station_id)):
-                add_lines.append([
-                    f"link{buses_station_id}_{b_it}",
-                    buses_station_id.index[0],
-                    buses_station_id.index[b_it],
-                    400000,
-                    1,
-                    0.0,
-                    False,
-                    False,
-                    "transmission",
-                    50,
-                    buses_station_id.country.iloc[0],
-                    LineString([
+                add_lines.append(
+                    [
+                        f"link{buses_station_id}_{b_it}",
+                        buses_station_id.index[0],
+                        buses_station_id.index[b_it],
+                        400000,
+                        1,
+                        0.0,
+                        False,
+                        False,
+                        "transmission",
+                        50,
+                        buses_station_id.country.iloc[0],
+                        LineString(
+                            [
+                                buses_station_id.geometry.iloc[0],
+                                buses_station_id.geometry.iloc[b_it],
+                            ]
+                        ),
+                        LineString(
+                            [
+                                buses_station_id.geometry.iloc[0],
+                                buses_station_id.geometry.iloc[b_it],
+                            ]
+                        ).bounds,
                         buses_station_id.geometry.iloc[0],
                         buses_station_id.geometry.iloc[b_it],
-                    ]),
-                    LineString([
-                        buses_station_id.geometry.iloc[0],
-                        buses_station_id.geometry.iloc[b_it],
-                    ]).bounds,
-                    buses_station_id.geometry.iloc[0],
-                    buses_station_id.geometry.iloc[b_it],
-                    buses_station_id.lon.iloc[0],
-                    buses_station_id.lat.iloc[0],
-                    buses_station_id.lon.iloc[b_it],
-                    buses_station_id.lat.iloc[b_it],
-                ])
-    return lines.append(gpd.GeoDataFrame(add_lines, columns=lines.keys()),
-                        ignore_index=True)
+                        buses_station_id.lon.iloc[0],
+                        buses_station_id.lat.iloc[0],
+                        buses_station_id.lon.iloc[b_it],
+                        buses_station_id.lat.iloc[b_it],
+                    ]
+                )
+    return lines.append(
+        gpd.GeoDataFrame(add_lines, columns=lines.keys()), ignore_index=True
+    )
 
 
 def set_lv_substations(buses):
@@ -393,17 +396,21 @@ def set_lv_substations(buses):
     buses["substation_lv"] = True
 
     # For each station number with multiple buses make lowest voltage `substation_lv = TRUE`
-    bus_with_stations_duplicates = buses[buses.station_id.duplicated(
-        keep=False)].sort_values(by=["station_id", "voltage"])
-    lv_bus_at_station_duplicates = (buses[buses.station_id.duplicated(
-        keep=False)].sort_values(by=["station_id", "voltage"]).drop_duplicates(
-            subset=["station_id"]))
+    bus_with_stations_duplicates = buses[
+        buses.station_id.duplicated(keep=False)
+    ].sort_values(by=["station_id", "voltage"])
+    lv_bus_at_station_duplicates = (
+        buses[buses.station_id.duplicated(keep=False)]
+        .sort_values(by=["station_id", "voltage"])
+        .drop_duplicates(subset=["station_id"])
+    )
     # Set all buses with station duplicates "False"
     buses.loc[bus_with_stations_duplicates.index, "substation_lv"] = False
     # Set lv_buses with station duplicates "True"
     buses.loc[lv_bus_at_station_duplicates.index, "substation_lv"] = True
 
     return buses
+
 
 # Note tolerance = 0.01 means around 700m
 # TODO: the current tolerance is high to avoid an issue in the Nigeria case where line 565939360-1
@@ -487,11 +494,9 @@ def create_station_at_equal_bus_locations(lines, buses, tol=0.01):
 
 def built_network(inputs, outputs):
     # ----------- LOAD DATA -----------
-    substations = gpd.read_file(
-        inputs["substations"]).set_crs(epsg=4326, inplace=True)
+    substations = gpd.read_file(inputs["substations"]).set_crs(epsg=4326, inplace=True)
     lines = gpd.read_file(inputs["lines"]).set_crs(epsg=4326, inplace=True)
-    generators = gpd.read_file(inputs["generators"]).set_crs(
-        epsg=4326, inplace=True)
+    generators = gpd.read_file(inputs["generators"]).set_crs(epsg=4326, inplace=True)
 
     # Filter only Nigeria
     # lines = lines[lines.loc[:,"country"] == "nigeria"].copy()
@@ -512,7 +517,8 @@ def built_network(inputs, outputs):
 
     # METHOD to merge buses with same voltage and within tolerance
     lines, buses = merge_stations_lines_by_station_id_and_voltage(
-        lines, buses, tol=0.05)
+        lines, buses, tol=0.05
+    )
 
     # Export data
     # Lines

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -485,6 +485,7 @@ def built_network(inputs, outputs):
     # ----------- LOAD DATA -----------
     substations = gpd.read_file(inputs["substations"]).set_crs(epsg=4326, inplace=True)
     lines = gpd.read_file(inputs["lines"]).set_crs(epsg=4326, inplace=True)
+    generators = gpd.read_file(inputs["generators"]).set_crs(epsg=4326, inplace=True)
 
     # Filter only Nigeria
     # lines = lines[lines.loc[:,"country"] == "nigeria"].copy()
@@ -530,6 +531,12 @@ def built_network(inputs, outputs):
         os.makedirs(os.path.dirname(outputs["substations"]), exist_ok=True)
     # Generate CSV
     _to_csv_nafix(buses, outputs["substations"])
+
+    # save generators
+    if not os.path.exists(outputs["generators"]):
+        os.makedirs(os.path.dirname(outputs["generators"]), exist_ok=True)
+    # Generate CSV
+    _to_csv_nafix(buses, outputs["generators"])
 
     return None
 

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -5,9 +5,13 @@ import sys
 
 import geopandas as gpd
 import numpy as np
-from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
-from shapely.geometry import LineString, Point
-from shapely.ops import linemerge, unary_union
+from _helpers import _sets_path_to_root
+from _helpers import _to_csv_nafix
+from _helpers import configure_logging
+from shapely.geometry import LineString
+from shapely.geometry import Point
+from shapely.ops import linemerge
+from shapely.ops import unary_union
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/osm_built_network.py
+++ b/scripts/osm_built_network.py
@@ -5,13 +5,9 @@ import sys
 
 import geopandas as gpd
 import numpy as np
-from _helpers import _sets_path_to_root
-from _helpers import _to_csv_nafix
-from _helpers import configure_logging
-from shapely.geometry import LineString
-from shapely.geometry import Point
-from shapely.ops import linemerge
-from shapely.ops import unary_union
+from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
+from shapely.geometry import LineString, Point
+from shapely.ops import linemerge, unary_union
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -71,7 +71,7 @@ def prepare_substation_df(df_all_substations):
     df_all_substations = df_all_substations[clist]
 
     # add the under_construction and dc
-    df_all_substations["under_construction"] = True
+    df_all_substations["under_construction"] = False
     df_all_substations["dc"] = False
 
     return df_all_substations
@@ -107,9 +107,9 @@ def add_line_endings_tosubstations(substations, lines):
 
     # Add NaN as default
     bus_all["station_id"] = np.nan
-    bus_all["dc"] = np.nan
+    bus_all["dc"] = False  # np.nan
     bus_all["under_construction"] = False  # Assuming substations completed for installed lines
-    bus_all["tag_area"] = np.nan
+    bus_all["tag_area"] = 0.0  # np.nan
     bus_all["symbol"] = "substation"
     bus_all["tag_substation"] = "transmission"  # TODO: this tag may be improved, maybe depending on voltage levels
 
@@ -462,8 +462,7 @@ def clean_data(
     names_by_shapes=True,
     tag_substation="transmission",
     threshold_voltage=35000,
-    add_line_endings=True,
-    group_close_buses=True,
+    add_line_endings=True
 ):
 
     # ----------- LINES AND CABLES -----------
@@ -591,8 +590,6 @@ if __name__ == "__main__":
         "names_by_shapes"]
     add_line_endings = snakemake.config["osm_data_cleaning_options"][
         "add_line_endings"]
-    group_close_buses = snakemake.config["osm_data_cleaning_options"][
-        "group_close_buses"]
     
     input_files = snakemake.input
     output_files = snakemake.output
@@ -617,6 +614,5 @@ if __name__ == "__main__":
         names_by_shapes=names_by_shapes,
         tag_substation=tag_substation,
         threshold_voltage=threshold_voltage,
-        add_line_endings=add_line_endings,
-        group_close_buses=group_close_buses
+        add_line_endings=add_line_endings
     )

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -6,9 +6,7 @@ import sys
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import _sets_path_to_root
-from _helpers import configure_logging
-from _helpers import _to_csv_nafix
+from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
 
 # from shapely.geometry import LineString, Point, Polygon
 # from osm_data_config import AFRICA_CC

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -77,7 +77,6 @@ def prepare_substation_df(df_all_substations):
     return df_all_substations
 
 
-
 def add_line_endings_tosubstations(substations, lines):
     # extract columns from substation df
     bus_s = gpd.GeoDataFrame(columns=substations.columns)
@@ -86,21 +85,21 @@ def add_line_endings_tosubstations(substations, lines):
     # Read information from line.csv
     bus_s[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_s["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[0]
-                                               if len(p.geoms) >= 2 else None)
+                                                    if len(p.geoms) >= 2 else None)
     bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x
-                                                 if p != None else None)
+                                         if p != None else None)
     bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y
-                                                 if p != None else None)
-    bus_s["bus_id"] = (substations["bus_id"].max() if "bus_id" in substations else 0) + 1 + bus_s.index
-
+                                         if p != None else None)
+    bus_s["bus_id"] = (substations["bus_id"].max()
+                       if "bus_id" in substations else 0) + 1 + bus_s.index
 
     bus_e[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_e["geometry"] = lines.geometry.boundary.map(lambda p: p.geoms[1]
-                                               if len(p.geoms) >= 2 else None)
+                                                    if len(p.geoms) >= 2 else None)
     bus_e["lon"] = bus_e["geometry"].map(lambda p: p.x
-                                                 if p != None else None)
+                                         if p != None else None)
     bus_e["lat"] = bus_e["geometry"].map(lambda p: p.y
-                                                 if p != None else None)
+                                         if p != None else None)
     bus_e["bus_id"] = bus_s["bus_id"].max() + 1 + bus_e.index
 
     bus_all = bus_s.append(bus_e).reset_index(drop=True)
@@ -108,10 +107,12 @@ def add_line_endings_tosubstations(substations, lines):
     # Add NaN as default
     bus_all["station_id"] = np.nan
     bus_all["dc"] = False  # np.nan
-    bus_all["under_construction"] = False  # Assuming substations completed for installed lines
+    # Assuming substations completed for installed lines
+    bus_all["under_construction"] = False
     bus_all["tag_area"] = 0.0  # np.nan
     bus_all["symbol"] = "substation"
-    bus_all["tag_substation"] = "transmission"  # TODO: this tag may be improved, maybe depending on voltage levels
+    # TODO: this tag may be improved, maybe depending on voltage levels
+    bus_all["tag_substation"] = "transmission"
 
     buses = substations.append(bus_all).reset_index(drop=True)
 
@@ -185,7 +186,6 @@ def add_line_endings_tosubstations(substations, lines):
 #                         sub_id = substation_id
 #                         break
 #                 buses.loc[buses.index[close_nodes], "station_id"] = sub_id
-
 
 
 def set_unique_id(df, col):
@@ -468,14 +468,16 @@ def clean_data(
     # ----------- LINES AND CABLES -----------
 
     # Load raw data lines
-    df_lines = gpd.read_file(input_files["lines"]).set_crs(epsg=4326, inplace=True)
+    df_lines = gpd.read_file(input_files["lines"]).set_crs(
+        epsg=4326, inplace=True)
 
     # prepare lines dataframe and data types
     df_lines = prepare_lines_df(df_lines)
     df_lines = finalize_lines_type(df_lines)
 
     # Load raw data lines
-    df_cables = gpd.read_file(input_files["cables"]).set_crs(epsg=4326, inplace=True)
+    df_cables = gpd.read_file(input_files["cables"]).set_crs(
+        epsg=4326, inplace=True)
 
     # prepare cables dataframe and data types
     df_cables = prepare_lines_df(df_cables)
@@ -513,7 +515,7 @@ def clean_data(
     # ----------- SUBSTATIONS -----------
 
     df_all_substations = gpd.read_file(input_files["substations"]).set_crs(
-                                           epsg=4326, inplace=True)
+        epsg=4326, inplace=True)
 
     # prepare dataset for substations
     df_all_substations = prepare_substation_df(df_all_substations)
@@ -530,7 +532,7 @@ def clean_data(
 
     # filter substation by voltage
     df_all_substations = filter_voltage(df_all_substations, threshold_voltage)
-    
+
     # # set substation_id
     # set_substations_ids(df_all_substations, tol=0.02)
 
@@ -557,7 +559,7 @@ def clean_data(
     # ----------- GENERATORS -----------
 
     df_all_generators = gpd.read_file(input_files["generators"]).set_crs(epsg=4326,
-                                                          inplace=True)
+                                                                         inplace=True)
 
     # prepare the generator dataset
     df_all_generators = prepare_generators_df(df_all_generators)
@@ -572,7 +574,7 @@ def clean_data(
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
-        
+
         # needed to run mock_snakemake
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -590,7 +592,7 @@ if __name__ == "__main__":
         "names_by_shapes"]
     add_line_endings = snakemake.config["osm_data_cleaning_options"][
         "add_line_endings"]
-    
+
     input_files = snakemake.input
     output_files = snakemake.output
 
@@ -598,10 +600,10 @@ if __name__ == "__main__":
     if names_by_shapes:
         country_shapes = (gpd.read_file(
             snakemake.input.country_shapes).set_index("name")
-                          ["geometry"].set_crs(4326))
+            ["geometry"].set_crs(4326))
         offshore_shapes = (gpd.read_file(
             snakemake.input.offshore_shapes).set_index("name")
-                           ["geometry"].set_crs(4326))
+            ["geometry"].set_crs(4326))
         ext_country_shapes = create_extended_country_shapes(
             country_shapes, offshore_shapes)
     else:

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -594,10 +594,10 @@ if __name__ == "__main__":
     if names_by_shapes:
         country_shapes = (gpd.read_file(
             snakemake.input.country_shapes).set_index("name")
-                          ["geometry"].set_crs(4326))
+            ["geometry"].set_crs(4326))
         offshore_shapes = (gpd.read_file(
             snakemake.input.offshore_shapes).set_index("name")
-                           ["geometry"].set_crs(4326))
+            ["geometry"].set_crs(4326))
         ext_country_shapes = create_extended_country_shapes(
             country_shapes, offshore_shapes)
     else:

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -6,9 +6,7 @@ import sys
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import _sets_path_to_root
-from _helpers import _to_csv_nafix
-from _helpers import configure_logging
+from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
 
 # from shapely.geometry import LineString, Point, Polygon
 # from osm_data_config import AFRICA_CC

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -6,7 +6,9 @@ import sys
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
+from _helpers import _sets_path_to_root
+from _helpers import _to_csv_nafix
+from _helpers import configure_logging
 
 # from shapely.geometry import LineString, Point, Polygon
 # from osm_data_config import AFRICA_CC

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -376,14 +376,14 @@ def integrate_lines_df(df_all_lines):
         df_all_lines.loc[(df_all_lines["cables"] == 4) |
                          (df_all_lines["cables"] == 5), "cables"] = 3
 
-    # where circuits are "0" make "1"
-    df_all_lines.loc[(df_all_lines["circuits"] == "0") |
-                     (df_all_lines["circuits"] == 0), "circuits"] = 1
-
     # one circuit contains 3 cable
     df_all_lines.loc[df_all_lines["circuits"].isna(), "circuits"] = (
         df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3)
     df_all_lines["circuits"] = df_all_lines["circuits"].astype(int)
+
+    # where circuits are "0" make "1"
+    df_all_lines.loc[(df_all_lines["circuits"] == "0") |
+                     (df_all_lines["circuits"] == 0), "circuits"] = 1
 
     # drop column if exist
     if "cables" in df_all_lines:

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -42,8 +42,7 @@ def prepare_substation_df(df_all_substations):
             "Country": "country",  # new/different to PyPSA-Eur
             "Area": "tag_area",
             "lonlat": "geometry",
-        }
-    )
+        })
 
     # Add longitute (lon) and latitude (lat) coordinates in the dataset
     df_all_substations["lon"] = df_all_substations["geometry"].x
@@ -86,20 +85,16 @@ def add_line_endings_tosubstations(substations, lines):
     # Read information from line.csv
     bus_s[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_s["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
-    )
+        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None)
     bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
     bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_s["bus_id"] = (
-        (substations["bus_id"].max() if "bus_id" in substations else 0)
-        + 1
-        + bus_s.index
-    )
+        (substations["bus_id"].max() if "bus_id" in substations else 0) + 1 +
+        bus_s.index)
 
     bus_e[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_e["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
-    )
+        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None)
     bus_e["lon"] = bus_e["geometry"].map(lambda p: p.x if p != None else None)
     bus_e["lat"] = bus_e["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = bus_s["bus_id"].max() + 1 + bus_e.index
@@ -232,12 +227,11 @@ def split_cells(df, lst_col="voltage"):
         Target column over which to perform the analysis
     """
     x = df.assign(**{lst_col: df[lst_col].str.split(";")})
-    x = pd.DataFrame(
-        {
-            col: np.repeat(x[col].values, x[lst_col].str.len())
-            for col in x.columns.difference([lst_col])
-        }
-    ).assign(**{lst_col: np.concatenate(x[lst_col].values)})[x.columns.tolist()]
+    x = pd.DataFrame({
+        col: np.repeat(x[col].values, x[lst_col].str.len())
+        for col in x.columns.difference([lst_col])
+    }).assign(
+        **{lst_col: np.concatenate(x[lst_col].values)})[x.columns.tolist()]
     return x
 
 
@@ -250,9 +244,8 @@ def filter_voltage(df, threshold_voltage=35000):
     df = split_cells(df)
 
     # Convert voltage to float, if impossible, discard row
-    df["voltage"] = (
-        df["voltage"].apply(lambda x: pd.to_numeric(x, errors="coerce")).astype(float)
-    )
+    df["voltage"] = (df["voltage"].apply(
+        lambda x: pd.to_numeric(x, errors="coerce")).astype(float))
     df = df.dropna(subset=["voltage"])  # Drop any row with Voltage = N/A
 
     # convert voltage to int
@@ -271,7 +264,9 @@ def finalize_substation_types(df_all_substations):
 
     # make float to integer
     df_all_substations["bus_id"] = df_all_substations["bus_id"].astype(int)
-    df_all_substations.loc[:, "voltage"] = df_all_substations["voltage"].astype(int)
+    df_all_substations.loc[:,
+                           "voltage"] = df_all_substations["voltage"].astype(
+                               int)
 
     return df_all_substations
 
@@ -298,8 +293,7 @@ def prepare_lines_df(df_lines):
             "lonlat": "geometry",
             "Country": "country",  # new/different to PyPSA-Eur
             "Length": "length",
-        }
-    )
+        })
 
     # Add NaN as default
     df_lines["bus0"] = np.nan
@@ -367,9 +361,8 @@ def integrate_lines_df(df_all_lines):
     # if not int make int
     if df_all_lines["cables"].dtype != int:
         # HERE. "0" if cables "None", "nan" or "1"
-        df_all_lines.loc[
-            (df_all_lines["cables"] < "3") | df_all_lines["cables"].isna(), "cables"
-        ] = "0"
+        df_all_lines.loc[(df_all_lines["cables"] < "3")
+                         | df_all_lines["cables"].isna(), "cables"] = "0"
         df_all_lines["cables"] = df_all_lines["cables"].astype("int")
 
     # downgrade 4 and 5 cables to 3...
@@ -377,20 +370,17 @@ def integrate_lines_df(df_all_lines):
         # Reason: 4 cables have 1 lighting protection cables, 5 cables has 2 LP cables - not transferring energy;
         # see https://hackaday.com/2019/06/11/a-field-guide-to-transmission-lines/
         # where circuits are "0" make "1"
-        df_all_lines.loc[
-            (df_all_lines["cables"] == 4) | (df_all_lines["cables"] == 5), "cables"
-        ] = 3
+        df_all_lines.loc[(df_all_lines["cables"] == 4) |
+                         (df_all_lines["cables"] == 5), "cables"] = 3
 
     # one circuit contains 3 cable
     df_all_lines.loc[df_all_lines["circuits"].isna(), "circuits"] = (
-        df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3
-    )
+        df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3)
     df_all_lines["circuits"] = df_all_lines["circuits"].astype(int)
 
     # where circuits are "0" make "1"
-    df_all_lines.loc[
-        (df_all_lines["circuits"] == "0") | (df_all_lines["circuits"] == 0), "circuits"
-    ] = 1
+    df_all_lines.loc[(df_all_lines["circuits"] == "0") |
+                     (df_all_lines["circuits"] == 0), "circuits"] = 1
 
     # drop column if exist
     if "cables" in df_all_lines:
@@ -409,16 +399,14 @@ def prepare_generators_df(df_all_generators):
 
     # rename columns
     df_all_generators = df_all_generators.rename(
-        columns={"tags.generator:output:electricity": "power_output_MW"}
-    )
+        columns={"tags.generator:output:electricity": "power_output_MW"})
 
     # convert electricity column from string to float value
     df_all_generators = df_all_generators[
-        df_all_generators["power_output_MW"].astype(str).str.contains("MW")
-    ]
+        df_all_generators["power_output_MW"].astype(str).str.contains("MW")]
     df_all_generators["power_output_MW"] = (
-        df_all_generators["power_output_MW"].str.extract("(\\d+)").astype(float)
-    )
+        df_all_generators["power_output_MW"].str.extract("(\\d+)").astype(
+            float))
 
     return df_all_generators
 
@@ -431,9 +419,10 @@ def find_first_overlap(geom, country_geoms, default_name):
     return default_name
 
 
-def set_countryname_by_shape(
-    df, ext_country_shapes, names_by_shapes=True, exclude_external=True
-):
+def set_countryname_by_shape(df,
+                             ext_country_shapes,
+                             names_by_shapes=True,
+                             exclude_external=True):
     "Set the country name by the name shape"
     if names_by_shapes:
         df["country"] = [
@@ -441,8 +430,7 @@ def set_countryname_by_shape(
                 row["geometry"],
                 ext_country_shapes,
                 None if exclude_external else row["country"],
-            )
-            for id, row in df.iterrows()
+            ) for id, row in df.iterrows()
         ]
         df.dropna(subset=["country"], inplace=True)
     return df
@@ -451,21 +439,15 @@ def set_countryname_by_shape(
 def create_extended_country_shapes(country_shapes, offshore_shapes):
     """Obtain the extended country shape by merging on- and off-shore shapes"""
 
-    merged_shapes = (
-        gpd.GeoDataFrame(
-            {
-                "name": list(country_shapes.index),
-                "geometry": [
-                    c_geom.unary_union(offshore_shapes[c_code])
-                    if c_code in offshore_shapes
-                    else c_geom
-                    for c_code, c_geom in country_shapes.items()
-                ],
-            }
-        )
-        .set_index("name")["geometry"]
-        .set_crs(4326)
-    )
+    merged_shapes = (gpd.GeoDataFrame({
+        "name":
+        list(country_shapes.index),
+        "geometry": [
+            c_geom.unary_union(offshore_shapes[c_code])
+            if c_code in offshore_shapes else c_geom
+            for c_code, c_geom in country_shapes.items()
+        ],
+    }).set_index("name")["geometry"].set_crs(4326))
 
     return merged_shapes
 
@@ -483,14 +465,16 @@ def clean_data(
     # ----------- LINES AND CABLES -----------
 
     # Load raw data lines
-    df_lines = gpd.read_file(input_files["lines"]).set_crs(epsg=4326, inplace=True)
+    df_lines = gpd.read_file(input_files["lines"]).set_crs(epsg=4326,
+                                                           inplace=True)
 
     # prepare lines dataframe and data types
     df_lines = prepare_lines_df(df_lines)
     df_lines = finalize_lines_type(df_lines)
 
     # Load raw data lines
-    df_cables = gpd.read_file(input_files["cables"]).set_crs(epsg=4326, inplace=True)
+    df_cables = gpd.read_file(input_files["cables"]).set_crs(epsg=4326,
+                                                             inplace=True)
 
     # prepare cables dataframe and data types
     df_cables = prepare_lines_df(df_cables)
@@ -507,27 +491,27 @@ def clean_data(
     df_all_lines = filter_voltage(df_all_lines, threshold_voltage)
 
     # remove lines without endings (Temporary fix for a Tanzanian line TODO: reformulation?)
-    df_all_lines = df_all_lines[
-        df_all_lines["geometry"].map(lambda g: len(g.boundary.geoms) >= 2)
-    ]
+    df_all_lines = df_all_lines[df_all_lines["geometry"].map(
+        lambda g: len(g.boundary.geoms) >= 2)]
 
     # set unique line ids
     df_all_lines = set_unique_id(df_all_lines, "line_id")
 
-    df_all_lines = gpd.GeoDataFrame(df_all_lines, geometry="geometry", crs="EPSG:4326")
+    df_all_lines = gpd.GeoDataFrame(df_all_lines,
+                                    geometry="geometry",
+                                    crs="EPSG:4326")
 
     # set the country name by the shape
-    df_all_lines = set_countryname_by_shape(
-        df_all_lines, ext_country_shapes, names_by_shapes=names_by_shapes
-    )
+    df_all_lines = set_countryname_by_shape(df_all_lines,
+                                            ext_country_shapes,
+                                            names_by_shapes=names_by_shapes)
 
     df_all_lines.to_file(output_files["lines"], driver="GeoJSON")
 
     # ----------- SUBSTATIONS -----------
 
     df_all_substations = gpd.read_file(input_files["substations"]).set_crs(
-        epsg=4326, inplace=True
-    )
+        epsg=4326, inplace=True)
 
     # prepare dataset for substations
     df_all_substations = prepare_substation_df(df_all_substations)
@@ -535,14 +519,12 @@ def clean_data(
     # add line endings if option is enabled
     if add_line_endings:
         df_all_substations = add_line_endings_tosubstations(
-            gpd.GeoDataFrame(), df_all_lines
-        )
+            gpd.GeoDataFrame(), df_all_lines)
 
     # filter substations by tag
     if tag_substation:  # if the string is not empty check it
         df_all_substations = df_all_substations[
-            df_all_substations["tag_substation"] == tag_substation
-        ]
+            df_all_substations["tag_substation"] == tag_substation]
 
     # filter substation by voltage
     df_all_substations = filter_voltage(df_all_substations, threshold_voltage)
@@ -557,22 +539,22 @@ def clean_data(
     df_all_substations = set_unique_id(df_all_substations, "bus_id")
 
     # save to geojson file
-    df_all_substations = gpd.GeoDataFrame(
-        df_all_substations, geometry="geometry", crs="EPSG:4326"
-    )
+    df_all_substations = gpd.GeoDataFrame(df_all_substations,
+                                          geometry="geometry",
+                                          crs="EPSG:4326")
 
     # set the country name by the shape
     df_all_substations = set_countryname_by_shape(
-        df_all_substations, ext_country_shapes, names_by_shapes=names_by_shapes
-    )
+        df_all_substations,
+        ext_country_shapes,
+        names_by_shapes=names_by_shapes)
 
     df_all_substations.to_file(output_files["substations"], driver="GeoJSON")
 
     # ----------- GENERATORS -----------
 
     df_all_generators = gpd.read_file(input_files["generators"]).set_crs(
-        epsg=4326, inplace=True
-    )
+        epsg=4326, inplace=True)
 
     # prepare the generator dataset
     df_all_generators = prepare_generators_df(df_all_generators)
@@ -596,31 +578,28 @@ if __name__ == "__main__":
     # Required to set path to pypsa-africa
     # _sets_path_to_root("pypsa-africa")
 
-    tag_substation = snakemake.config["osm_data_cleaning_options"]["tag_substation"]
+    tag_substation = snakemake.config["osm_data_cleaning_options"][
+        "tag_substation"]
     threshold_voltage = snakemake.config["osm_data_cleaning_options"][
-        "threshold_voltage"
-    ]
-    names_by_shapes = snakemake.config["osm_data_cleaning_options"]["names_by_shapes"]
-    add_line_endings = snakemake.config["osm_data_cleaning_options"]["add_line_endings"]
+        "threshold_voltage"]
+    names_by_shapes = snakemake.config["osm_data_cleaning_options"][
+        "names_by_shapes"]
+    add_line_endings = snakemake.config["osm_data_cleaning_options"][
+        "add_line_endings"]
 
     input_files = snakemake.input
     output_files = snakemake.output
 
     # only when country names are defined by shapes, load the info
     if names_by_shapes:
-        country_shapes = (
-            gpd.read_file(snakemake.input.country_shapes)
-            .set_index("name")["geometry"]
-            .set_crs(4326)
-        )
-        offshore_shapes = (
-            gpd.read_file(snakemake.input.offshore_shapes)
-            .set_index("name")["geometry"]
-            .set_crs(4326)
-        )
+        country_shapes = (gpd.read_file(
+            snakemake.input.country_shapes).set_index("name")
+                          ["geometry"].set_crs(4326))
+        offshore_shapes = (gpd.read_file(
+            snakemake.input.offshore_shapes).set_index("name")
+                           ["geometry"].set_crs(4326))
         ext_country_shapes = create_extended_country_shapes(
-            country_shapes, offshore_shapes
-        )
+            country_shapes, offshore_shapes)
     else:
         ext_country_shapes = None
 

--- a/scripts/osm_data_cleaning.py
+++ b/scripts/osm_data_cleaning.py
@@ -42,7 +42,8 @@ def prepare_substation_df(df_all_substations):
             "Country": "country",  # new/different to PyPSA-Eur
             "Area": "tag_area",
             "lonlat": "geometry",
-        })
+        }
+    )
 
     # Add longitute (lon) and latitude (lat) coordinates in the dataset
     df_all_substations["lon"] = df_all_substations["geometry"].x
@@ -85,16 +86,20 @@ def add_line_endings_tosubstations(substations, lines):
     # Read information from line.csv
     bus_s[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_s["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None)
+        lambda p: p.geoms[0] if len(p.geoms) >= 2 else None
+    )
     bus_s["lon"] = bus_s["geometry"].map(lambda p: p.x if p != None else None)
     bus_s["lat"] = bus_s["geometry"].map(lambda p: p.y if p != None else None)
     bus_s["bus_id"] = (
-        (substations["bus_id"].max() if "bus_id" in substations else 0) + 1 +
-        bus_s.index)
+        (substations["bus_id"].max() if "bus_id" in substations else 0)
+        + 1
+        + bus_s.index
+    )
 
     bus_e[["voltage", "country"]] = lines[["voltage", "country"]].astype(str)
     bus_e["geometry"] = lines.geometry.boundary.map(
-        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None)
+        lambda p: p.geoms[1] if len(p.geoms) >= 2 else None
+    )
     bus_e["lon"] = bus_e["geometry"].map(lambda p: p.x if p != None else None)
     bus_e["lat"] = bus_e["geometry"].map(lambda p: p.y if p != None else None)
     bus_e["bus_id"] = bus_s["bus_id"].max() + 1 + bus_e.index
@@ -227,11 +232,12 @@ def split_cells(df, lst_col="voltage"):
         Target column over which to perform the analysis
     """
     x = df.assign(**{lst_col: df[lst_col].str.split(";")})
-    x = pd.DataFrame({
-        col: np.repeat(x[col].values, x[lst_col].str.len())
-        for col in x.columns.difference([lst_col])
-    }).assign(
-        **{lst_col: np.concatenate(x[lst_col].values)})[x.columns.tolist()]
+    x = pd.DataFrame(
+        {
+            col: np.repeat(x[col].values, x[lst_col].str.len())
+            for col in x.columns.difference([lst_col])
+        }
+    ).assign(**{lst_col: np.concatenate(x[lst_col].values)})[x.columns.tolist()]
     return x
 
 
@@ -244,8 +250,9 @@ def filter_voltage(df, threshold_voltage=35000):
     df = split_cells(df)
 
     # Convert voltage to float, if impossible, discard row
-    df["voltage"] = (df["voltage"].apply(
-        lambda x: pd.to_numeric(x, errors="coerce")).astype(float))
+    df["voltage"] = (
+        df["voltage"].apply(lambda x: pd.to_numeric(x, errors="coerce")).astype(float)
+    )
     df = df.dropna(subset=["voltage"])  # Drop any row with Voltage = N/A
 
     # convert voltage to int
@@ -264,9 +271,7 @@ def finalize_substation_types(df_all_substations):
 
     # make float to integer
     df_all_substations["bus_id"] = df_all_substations["bus_id"].astype(int)
-    df_all_substations.loc[:,
-                           "voltage"] = df_all_substations["voltage"].astype(
-                               int)
+    df_all_substations.loc[:, "voltage"] = df_all_substations["voltage"].astype(int)
 
     return df_all_substations
 
@@ -293,7 +298,8 @@ def prepare_lines_df(df_lines):
             "lonlat": "geometry",
             "Country": "country",  # new/different to PyPSA-Eur
             "Length": "length",
-        })
+        }
+    )
 
     # Add NaN as default
     df_lines["bus0"] = np.nan
@@ -361,8 +367,9 @@ def integrate_lines_df(df_all_lines):
     # if not int make int
     if df_all_lines["cables"].dtype != int:
         # HERE. "0" if cables "None", "nan" or "1"
-        df_all_lines.loc[(df_all_lines["cables"] < "3")
-                         | df_all_lines["cables"].isna(), "cables"] = "0"
+        df_all_lines.loc[
+            (df_all_lines["cables"] < "3") | df_all_lines["cables"].isna(), "cables"
+        ] = "0"
         df_all_lines["cables"] = df_all_lines["cables"].astype("int")
 
     # downgrade 4 and 5 cables to 3...
@@ -370,17 +377,20 @@ def integrate_lines_df(df_all_lines):
         # Reason: 4 cables have 1 lighting protection cables, 5 cables has 2 LP cables - not transferring energy;
         # see https://hackaday.com/2019/06/11/a-field-guide-to-transmission-lines/
         # where circuits are "0" make "1"
-        df_all_lines.loc[(df_all_lines["cables"] == 4) |
-                         (df_all_lines["cables"] == 5), "cables"] = 3
+        df_all_lines.loc[
+            (df_all_lines["cables"] == 4) | (df_all_lines["cables"] == 5), "cables"
+        ] = 3
 
     # one circuit contains 3 cable
     df_all_lines.loc[df_all_lines["circuits"].isna(), "circuits"] = (
-        df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3)
+        df_all_lines.loc[df_all_lines["circuits"].isna(), "cables"] / 3
+    )
     df_all_lines["circuits"] = df_all_lines["circuits"].astype(int)
 
     # where circuits are "0" make "1"
-    df_all_lines.loc[(df_all_lines["circuits"] == "0") |
-                     (df_all_lines["circuits"] == 0), "circuits"] = 1
+    df_all_lines.loc[
+        (df_all_lines["circuits"] == "0") | (df_all_lines["circuits"] == 0), "circuits"
+    ] = 1
 
     # drop column if exist
     if "cables" in df_all_lines:
@@ -399,14 +409,16 @@ def prepare_generators_df(df_all_generators):
 
     # rename columns
     df_all_generators = df_all_generators.rename(
-        columns={"tags.generator:output:electricity": "power_output_MW"})
+        columns={"tags.generator:output:electricity": "power_output_MW"}
+    )
 
     # convert electricity column from string to float value
     df_all_generators = df_all_generators[
-        df_all_generators["power_output_MW"].astype(str).str.contains("MW")]
+        df_all_generators["power_output_MW"].astype(str).str.contains("MW")
+    ]
     df_all_generators["power_output_MW"] = (
-        df_all_generators["power_output_MW"].str.extract("(\\d+)").astype(
-            float))
+        df_all_generators["power_output_MW"].str.extract("(\\d+)").astype(float)
+    )
 
     return df_all_generators
 
@@ -419,10 +431,9 @@ def find_first_overlap(geom, country_geoms, default_name):
     return default_name
 
 
-def set_countryname_by_shape(df,
-                             ext_country_shapes,
-                             names_by_shapes=True,
-                             exclude_external=True):
+def set_countryname_by_shape(
+    df, ext_country_shapes, names_by_shapes=True, exclude_external=True
+):
     "Set the country name by the name shape"
     if names_by_shapes:
         df["country"] = [
@@ -430,7 +441,8 @@ def set_countryname_by_shape(df,
                 row["geometry"],
                 ext_country_shapes,
                 None if exclude_external else row["country"],
-            ) for id, row in df.iterrows()
+            )
+            for id, row in df.iterrows()
         ]
         df.dropna(subset=["country"], inplace=True)
     return df
@@ -439,15 +451,21 @@ def set_countryname_by_shape(df,
 def create_extended_country_shapes(country_shapes, offshore_shapes):
     """Obtain the extended country shape by merging on- and off-shore shapes"""
 
-    merged_shapes = (gpd.GeoDataFrame({
-        "name":
-        list(country_shapes.index),
-        "geometry": [
-            c_geom.unary_union(offshore_shapes[c_code])
-            if c_code in offshore_shapes else c_geom
-            for c_code, c_geom in country_shapes.items()
-        ],
-    }).set_index("name")["geometry"].set_crs(4326))
+    merged_shapes = (
+        gpd.GeoDataFrame(
+            {
+                "name": list(country_shapes.index),
+                "geometry": [
+                    c_geom.unary_union(offshore_shapes[c_code])
+                    if c_code in offshore_shapes
+                    else c_geom
+                    for c_code, c_geom in country_shapes.items()
+                ],
+            }
+        )
+        .set_index("name")["geometry"]
+        .set_crs(4326)
+    )
 
     return merged_shapes
 
@@ -465,16 +483,14 @@ def clean_data(
     # ----------- LINES AND CABLES -----------
 
     # Load raw data lines
-    df_lines = gpd.read_file(input_files["lines"]).set_crs(epsg=4326,
-                                                           inplace=True)
+    df_lines = gpd.read_file(input_files["lines"]).set_crs(epsg=4326, inplace=True)
 
     # prepare lines dataframe and data types
     df_lines = prepare_lines_df(df_lines)
     df_lines = finalize_lines_type(df_lines)
 
     # Load raw data lines
-    df_cables = gpd.read_file(input_files["cables"]).set_crs(epsg=4326,
-                                                             inplace=True)
+    df_cables = gpd.read_file(input_files["cables"]).set_crs(epsg=4326, inplace=True)
 
     # prepare cables dataframe and data types
     df_cables = prepare_lines_df(df_cables)
@@ -491,27 +507,27 @@ def clean_data(
     df_all_lines = filter_voltage(df_all_lines, threshold_voltage)
 
     # remove lines without endings (Temporary fix for a Tanzanian line TODO: reformulation?)
-    df_all_lines = df_all_lines[df_all_lines["geometry"].map(
-        lambda g: len(g.boundary.geoms) >= 2)]
+    df_all_lines = df_all_lines[
+        df_all_lines["geometry"].map(lambda g: len(g.boundary.geoms) >= 2)
+    ]
 
     # set unique line ids
     df_all_lines = set_unique_id(df_all_lines, "line_id")
 
-    df_all_lines = gpd.GeoDataFrame(df_all_lines,
-                                    geometry="geometry",
-                                    crs="EPSG:4326")
+    df_all_lines = gpd.GeoDataFrame(df_all_lines, geometry="geometry", crs="EPSG:4326")
 
     # set the country name by the shape
-    df_all_lines = set_countryname_by_shape(df_all_lines,
-                                            ext_country_shapes,
-                                            names_by_shapes=names_by_shapes)
+    df_all_lines = set_countryname_by_shape(
+        df_all_lines, ext_country_shapes, names_by_shapes=names_by_shapes
+    )
 
     df_all_lines.to_file(output_files["lines"], driver="GeoJSON")
 
     # ----------- SUBSTATIONS -----------
 
     df_all_substations = gpd.read_file(input_files["substations"]).set_crs(
-        epsg=4326, inplace=True)
+        epsg=4326, inplace=True
+    )
 
     # prepare dataset for substations
     df_all_substations = prepare_substation_df(df_all_substations)
@@ -519,12 +535,14 @@ def clean_data(
     # add line endings if option is enabled
     if add_line_endings:
         df_all_substations = add_line_endings_tosubstations(
-            gpd.GeoDataFrame(), df_all_lines)
+            gpd.GeoDataFrame(), df_all_lines
+        )
 
     # filter substations by tag
     if tag_substation:  # if the string is not empty check it
         df_all_substations = df_all_substations[
-            df_all_substations["tag_substation"] == tag_substation]
+            df_all_substations["tag_substation"] == tag_substation
+        ]
 
     # filter substation by voltage
     df_all_substations = filter_voltage(df_all_substations, threshold_voltage)
@@ -539,22 +557,22 @@ def clean_data(
     df_all_substations = set_unique_id(df_all_substations, "bus_id")
 
     # save to geojson file
-    df_all_substations = gpd.GeoDataFrame(df_all_substations,
-                                          geometry="geometry",
-                                          crs="EPSG:4326")
+    df_all_substations = gpd.GeoDataFrame(
+        df_all_substations, geometry="geometry", crs="EPSG:4326"
+    )
 
     # set the country name by the shape
     df_all_substations = set_countryname_by_shape(
-        df_all_substations,
-        ext_country_shapes,
-        names_by_shapes=names_by_shapes)
+        df_all_substations, ext_country_shapes, names_by_shapes=names_by_shapes
+    )
 
     df_all_substations.to_file(output_files["substations"], driver="GeoJSON")
 
     # ----------- GENERATORS -----------
 
     df_all_generators = gpd.read_file(input_files["generators"]).set_crs(
-        epsg=4326, inplace=True)
+        epsg=4326, inplace=True
+    )
 
     # prepare the generator dataset
     df_all_generators = prepare_generators_df(df_all_generators)
@@ -578,28 +596,31 @@ if __name__ == "__main__":
     # Required to set path to pypsa-africa
     # _sets_path_to_root("pypsa-africa")
 
-    tag_substation = snakemake.config["osm_data_cleaning_options"][
-        "tag_substation"]
+    tag_substation = snakemake.config["osm_data_cleaning_options"]["tag_substation"]
     threshold_voltage = snakemake.config["osm_data_cleaning_options"][
-        "threshold_voltage"]
-    names_by_shapes = snakemake.config["osm_data_cleaning_options"][
-        "names_by_shapes"]
-    add_line_endings = snakemake.config["osm_data_cleaning_options"][
-        "add_line_endings"]
+        "threshold_voltage"
+    ]
+    names_by_shapes = snakemake.config["osm_data_cleaning_options"]["names_by_shapes"]
+    add_line_endings = snakemake.config["osm_data_cleaning_options"]["add_line_endings"]
 
     input_files = snakemake.input
     output_files = snakemake.output
 
     # only when country names are defined by shapes, load the info
     if names_by_shapes:
-        country_shapes = (gpd.read_file(
-            snakemake.input.country_shapes).set_index("name")
-            ["geometry"].set_crs(4326))
-        offshore_shapes = (gpd.read_file(
-            snakemake.input.offshore_shapes).set_index("name")
-            ["geometry"].set_crs(4326))
+        country_shapes = (
+            gpd.read_file(snakemake.input.country_shapes)
+            .set_index("name")["geometry"]
+            .set_crs(4326)
+        )
+        offshore_shapes = (
+            gpd.read_file(snakemake.input.offshore_shapes)
+            .set_index("name")["geometry"]
+            .set_crs(4326)
+        )
         ext_country_shapes = create_extended_country_shapes(
-            country_shapes, offshore_shapes)
+            country_shapes, offshore_shapes
+        )
     else:
         ext_country_shapes = None
 

--- a/scripts/osm_pbf_power_data_extractor.py
+++ b/scripts/osm_pbf_power_data_extractor.py
@@ -84,9 +84,8 @@ def download_pbf(country_code, update, verify):
     geofabrik_filename = f"{country_name}-latest.osm.pbf"
     # https://download.geofabrik.de/africa/nigeria-latest.osm.pbf
     geofabrik_url = f"https://download.geofabrik.de/{continent}/{geofabrik_filename}"
-    PBF_inputfile = os.path.join(
-        os.getcwd(), "data", "osm", continent, "pbf", geofabrik_filename
-    )  # Input filepath
+    PBF_inputfile = os.path.join(os.getcwd(), "data", "osm", continent, "pbf",
+                                 geofabrik_filename)  # Input filepath
 
     if not os.path.exists(PBF_inputfile):
         _logger.info(f"{geofabrik_filename} downloading to {PBF_inputfile}")
@@ -179,24 +178,22 @@ def download_and_filter(feature, country_code, update=False, verify=False):
 
     filter_file_exists = False
     # json file for the Data dictionary
-    JSON_outputfile = os.path.join(
-        os.getcwd(), "data", "osm", continent, country_code + "_power.json"
-    )
+    JSON_outputfile = os.path.join(os.getcwd(), "data", "osm", continent,
+                                   country_code + "_power.json")
     # json file for the Elements dictionary is automatically written to "data/osm/Elements"+filename)
 
     if os.path.exists(JSON_outputfile):
         filter_file_exists = True
 
     if not os.path.exists(
-        os.path.join(
-            os.getcwd(),
-            "data",
-            "osm",
-            continent,
-            "Elements",
-            country_code + f"_{feature}s.json",
-        )
-    ):
+            os.path.join(
+                os.getcwd(),
+                "data",
+                "osm",
+                continent,
+                "Elements",
+                country_code + f"_{feature}s.json",
+            )):
         _logger.warning("Element file not found so pre-filtering")
         filter_file_exists = False
 
@@ -219,8 +216,7 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         osm_pickle.picklesave(
             DataDict,
             os.path.realpath(
-                os.path.join(os.getcwd(), os.path.dirname(JSON_outputfile))
-            ),
+                os.path.join(os.getcwd(), os.path.dirname(JSON_outputfile))),
         )
 
         _logger.info(f"Loading {feature} Pickle for {country_name}")
@@ -238,9 +234,15 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         _logger.info(f"Creating new {feature} Elements for {country_name}")
 
     prefilter = {
-        Node: {"power": feature_list},
-        Way: {"power": feature_list},
-        Relation: {"power": feature_list},
+        Node: {
+            "power": feature_list
+        },
+        Way: {
+            "power": feature_list
+        },
+        Relation: {
+            "power": feature_list
+        },
     }  # see https://dlr-ve-esy.gitlab.io/esy-osmfilter/filter.html for filter structures
 
     blackfilter = [
@@ -267,9 +269,8 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         multiprocess=True,
     )
 
-    logging.disable(
-        logging.NOTSET
-    )  # Re-enable logging as run_filter disables logging.INFO
+    logging.disable(logging.NOTSET
+                    )  # Re-enable logging as run_filter disables logging.INFO
     _logger.info(
         f"Pre: {new_prefilter_data}, Elem: {create_elements}, for {feature} in {country_code}"
     )
@@ -301,7 +302,8 @@ def lonlat_lookup(df_way, Data):
         # df_way[col] = pd.Series([], dtype=pd.StringDtype()).astype(float)  # create empty "refs" if not in dataframe
 
     def look(ref):
-        lonlat_row = list(map(lambda r: tuple(Data["Node"][str(r)]["lonlat"]), ref))
+        lonlat_row = list(
+            map(lambda r: tuple(Data["Node"][str(r)]["lonlat"]), ref))
         return lonlat_row
 
     lonlat_list = df_way["refs"].apply(look)
@@ -316,22 +318,19 @@ def convert_ways_points(df_way, Data):
     lonlat_list = lonlat_lookup(df_way, Data)
     way_polygon = list(
         map(
-            lambda lonlat: Polygon(lonlat) if len(lonlat) >= 3 else Point(lonlat[0]),
+            lambda lonlat: Polygon(lonlat)
+            if len(lonlat) >= 3 else Point(lonlat[0]),
             lonlat_list,
-        )
-    )
+        ))
     area_column = list(
         map(
             int,
             round(
-                gpd.GeoSeries(way_polygon)
-                .set_crs("EPSG:4326")
-                .to_crs("EPSG:3857")
-                .area,
+                gpd.GeoSeries(way_polygon).set_crs("EPSG:4326").to_crs(
+                    "EPSG:3857").area,
                 -1,
             ),
-        )
-    )  # TODO: Rounding should be down in cleaning scripts
+        ))  # TODO: Rounding should be down in cleaning scripts
 
     def find_center_point(p):
         if p.geom_type == "Polygon":
@@ -356,9 +355,8 @@ def convert_ways_lines(df_way, Data):
     df_way.insert(0, "lonlat", lonlat_column)
 
     way_linestring = map(lambda lonlats: LineString(lonlats), lonlat_list)
-    length_column = (
-        gpd.GeoSeries(way_linestring).set_crs("EPSG:4326").to_crs("EPSG:3857").length
-    )
+    length_column = (gpd.GeoSeries(way_linestring).set_crs("EPSG:4326").to_crs(
+        "EPSG:3857").length)
 
     df_way.insert(0, "Length", length_column)
 
@@ -367,9 +365,9 @@ def convert_ways_lines(df_way, Data):
 
 
 def convert_pd_to_gdf_nodes(df_way):
-    gdf = gpd.GeoDataFrame(
-        df_way, geometry=[Point(x, y) for x, y in df_way.lonlat], crs="EPSG:4326"
-    )
+    gdf = gpd.GeoDataFrame(df_way,
+                           geometry=[Point(x, y) for x, y in df_way.lonlat],
+                           crs="EPSG:4326")
     gdf.drop(columns=["lonlat"], inplace=True)
     return gdf
 
@@ -381,17 +379,18 @@ def convert_pd_to_gdf_lines(df_way, simplified=False):
     # df_way["geometry"] = df_way["lonlat"].apply(lambda x: LineString(x))
     if simplified is True:
         df_way["geometry"] = df_way["geometry"].apply(
-            lambda x: x.simplify(0.005, preserve_topology=False)
-        )
-    gdf = gpd.GeoDataFrame(
-        df_way, geometry=[LineString(x) for x in df_way.lonlat], crs="EPSG:4326"
-    )
+            lambda x: x.simplify(0.005, preserve_topology=False))
+    gdf = gpd.GeoDataFrame(df_way,
+                           geometry=[LineString(x) for x in df_way.lonlat],
+                           crs="EPSG:4326")
     gdf.drop(columns=["lonlat"], inplace=True)
 
     return gdf
 
 
-def convert_iso_to_geofk(iso_code, iso_coding=True, convert_dict=iso_to_geofk_dict):
+def convert_iso_to_geofk(iso_code,
+                         iso_coding=True,
+                         convert_dict=iso_to_geofk_dict):
     """Function to convert the iso code name of a country into the corresponding geofabrik"""
     if iso_code in convert_dict:
         if not iso_coding:
@@ -407,18 +406,16 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
     "Function to save the feature as csv and geojson"
 
     continent, country_name = getContinentCountry(country_code)
-    outputfile_partial = os.path.join(
-        os.getcwd(), "data", "raw", continent + "_all" "_raw"
-    )  # Output file directory
+    outputfile_partial = os.path.join(os.getcwd(), "data", "raw",
+                                      continent + "_all"
+                                      "_raw")  # Output file directory
 
     if not os.path.exists(outputfile_partial):
-        os.makedirs(
-            os.path.dirname(outputfile_partial), exist_ok=True
-        )  # create raw directory
+        os.makedirs(os.path.dirname(outputfile_partial),
+                    exist_ok=True)  # create raw directory
 
-    df_all_feature = df_all_feature[
-        df_all_feature.columns.intersection(set(columns_feature))
-    ]
+    df_all_feature = df_all_feature[df_all_feature.columns.intersection(
+        set(columns_feature))]
     df_all_feature.reset_index(drop=True, inplace=True)
 
     # Generate Files
@@ -427,9 +424,8 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
         _logger.warning(f"All feature data frame empty for {feature}")
         return None
 
-    _to_csv_nafix(
-        df_all_feature, outputfile_partial + f"_{feature}s" + ".csv"
-    )  # Generate CSV
+    _to_csv_nafix(df_all_feature,
+                  outputfile_partial + f"_{feature}s" + ".csv")  # Generate CSV
 
     if feature_category[feature] == "way":
         gdf_feature = convert_pd_to_gdf_lines(df_all_feature)
@@ -437,9 +433,8 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
         gdf_feature = convert_pd_to_gdf_nodes(df_all_feature)
 
     _logger.info("Writing GeoJSON file")
-    gdf_feature.to_file(
-        outputfile_partial + f"_{feature}s" + ".geojson", driver="GeoJSON"
-    )  # Generate GeoJson
+    gdf_feature.to_file(outputfile_partial + f"_{feature}s" + ".geojson",
+                        driver="GeoJSON")  # Generate GeoJson
 
 
 def process_data(country_list, iso_coding=True, update=False, verify=False):
@@ -454,20 +449,19 @@ def process_data(country_list, iso_coding=True, update=False, verify=False):
         df_all_feature = pd.DataFrame()
         for country_code_isogeofk in country_list:
 
-            country_code = convert_iso_to_geofk(country_code_isogeofk, iso_coding)
+            country_code = convert_iso_to_geofk(country_code_isogeofk,
+                                                iso_coding)
 
-            feature_data = download_and_filter(feature, country_code, update, verify)
+            feature_data = download_and_filter(feature, country_code, update,
+                                               verify)
 
             df_node, df_way, Data = convert_filtered_data_to_dfs(
-                country_code, feature_data, feature
-            )
+                country_code, feature_data, feature)
 
             if feature_category[feature] == "way":
                 convert_ways_lines(
-                    df_way, Data
-                ) if not df_way.empty else _logger.warning(
-                    f"Empty Way Dataframe for {feature} in {country_code}"
-                )
+                    df_way, Data) if not df_way.empty else _logger.warning(
+                        f"Empty Way Dataframe for {feature} in {country_code}")
                 if not df_node.empty:
                     _logger.warning(
                         f"Node dataframe not empty for {feature} in {country_code}"
@@ -488,9 +482,8 @@ def process_data(country_list, iso_coding=True, update=False, verify=False):
 
             df_all_feature = pd.concat([df_all_feature, df_feature])
 
-        output_csv_geojson(
-            country_code, df_all_feature, feature_columns[feature], feature
-        )
+        output_csv_geojson(country_code, df_all_feature,
+                           feature_columns[feature], feature)
 
 
 def create_country_list(input, iso_coding=True):
@@ -514,7 +507,6 @@ def create_country_list(input, iso_coding=True):
     full_codes_list : list
         Example ["NG","ZA"]
     """
-
     def filter_codes(c_list, iso_coding=True):
         """
         Filter list according to the specified coding.

--- a/scripts/osm_pbf_power_data_extractor.py
+++ b/scripts/osm_pbf_power_data_extractor.py
@@ -19,25 +19,15 @@ import geopandas as gpd
 import pandas as pd
 import requests
 import urllib3
-from _helpers import _sets_path_to_root
-from _helpers import _to_csv_nafix
-from _helpers import configure_logging
-from esy.osmfilter import Node
+from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
+from esy.osmfilter import Node, Relation, Way
 from esy.osmfilter import osm_info as osm_info
 from esy.osmfilter import osm_pickle as osm_pickle
-from esy.osmfilter import Relation
 from esy.osmfilter import run_filter
-from esy.osmfilter import Way
-from osm_data_config import continent_regions
-from osm_data_config import continents
-from osm_data_config import feature_category
-from osm_data_config import feature_columns
-from osm_data_config import iso_to_geofk_dict
-from osm_data_config import world
+from osm_data_config import (continent_regions, continents, feature_category,
+                             feature_columns, iso_to_geofk_dict, world)
 from shapely import geometry
-from shapely.geometry import LineString
-from shapely.geometry import Point
-from shapely.geometry import Polygon
+from shapely.geometry import LineString, Point, Polygon
 
 # https://gitlab.com/dlr-ve-esy/esy-osmfilter/-/tree/master/
 

--- a/scripts/osm_pbf_power_data_extractor.py
+++ b/scripts/osm_pbf_power_data_extractor.py
@@ -19,15 +19,25 @@ import geopandas as gpd
 import pandas as pd
 import requests
 import urllib3
-from _helpers import _sets_path_to_root, _to_csv_nafix, configure_logging
-from esy.osmfilter import Node, Relation, Way
+from _helpers import _sets_path_to_root
+from _helpers import _to_csv_nafix
+from _helpers import configure_logging
+from esy.osmfilter import Node
 from esy.osmfilter import osm_info as osm_info
 from esy.osmfilter import osm_pickle as osm_pickle
+from esy.osmfilter import Relation
 from esy.osmfilter import run_filter
-from osm_data_config import (continent_regions, continents, feature_category,
-                             feature_columns, iso_to_geofk_dict, world)
+from esy.osmfilter import Way
+from osm_data_config import continent_regions
+from osm_data_config import continents
+from osm_data_config import feature_category
+from osm_data_config import feature_columns
+from osm_data_config import iso_to_geofk_dict
+from osm_data_config import world
 from shapely import geometry
-from shapely.geometry import LineString, Point, Polygon
+from shapely.geometry import LineString
+from shapely.geometry import Point
+from shapely.geometry import Polygon
 
 # https://gitlab.com/dlr-ve-esy/esy-osmfilter/-/tree/master/
 

--- a/scripts/osm_pbf_power_data_extractor.py
+++ b/scripts/osm_pbf_power_data_extractor.py
@@ -84,8 +84,9 @@ def download_pbf(country_code, update, verify):
     geofabrik_filename = f"{country_name}-latest.osm.pbf"
     # https://download.geofabrik.de/africa/nigeria-latest.osm.pbf
     geofabrik_url = f"https://download.geofabrik.de/{continent}/{geofabrik_filename}"
-    PBF_inputfile = os.path.join(os.getcwd(), "data", "osm", continent, "pbf",
-                                 geofabrik_filename)  # Input filepath
+    PBF_inputfile = os.path.join(
+        os.getcwd(), "data", "osm", continent, "pbf", geofabrik_filename
+    )  # Input filepath
 
     if not os.path.exists(PBF_inputfile):
         _logger.info(f"{geofabrik_filename} downloading to {PBF_inputfile}")
@@ -178,22 +179,24 @@ def download_and_filter(feature, country_code, update=False, verify=False):
 
     filter_file_exists = False
     # json file for the Data dictionary
-    JSON_outputfile = os.path.join(os.getcwd(), "data", "osm", continent,
-                                   country_code + "_power.json")
+    JSON_outputfile = os.path.join(
+        os.getcwd(), "data", "osm", continent, country_code + "_power.json"
+    )
     # json file for the Elements dictionary is automatically written to "data/osm/Elements"+filename)
 
     if os.path.exists(JSON_outputfile):
         filter_file_exists = True
 
     if not os.path.exists(
-            os.path.join(
-                os.getcwd(),
-                "data",
-                "osm",
-                continent,
-                "Elements",
-                country_code + f"_{feature}s.json",
-            )):
+        os.path.join(
+            os.getcwd(),
+            "data",
+            "osm",
+            continent,
+            "Elements",
+            country_code + f"_{feature}s.json",
+        )
+    ):
         _logger.warning("Element file not found so pre-filtering")
         filter_file_exists = False
 
@@ -216,7 +219,8 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         osm_pickle.picklesave(
             DataDict,
             os.path.realpath(
-                os.path.join(os.getcwd(), os.path.dirname(JSON_outputfile))),
+                os.path.join(os.getcwd(), os.path.dirname(JSON_outputfile))
+            ),
         )
 
         _logger.info(f"Loading {feature} Pickle for {country_name}")
@@ -234,15 +238,9 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         _logger.info(f"Creating new {feature} Elements for {country_name}")
 
     prefilter = {
-        Node: {
-            "power": feature_list
-        },
-        Way: {
-            "power": feature_list
-        },
-        Relation: {
-            "power": feature_list
-        },
+        Node: {"power": feature_list},
+        Way: {"power": feature_list},
+        Relation: {"power": feature_list},
     }  # see https://dlr-ve-esy.gitlab.io/esy-osmfilter/filter.html for filter structures
 
     blackfilter = [
@@ -269,8 +267,9 @@ def download_and_filter(feature, country_code, update=False, verify=False):
         multiprocess=True,
     )
 
-    logging.disable(logging.NOTSET
-                    )  # Re-enable logging as run_filter disables logging.INFO
+    logging.disable(
+        logging.NOTSET
+    )  # Re-enable logging as run_filter disables logging.INFO
     _logger.info(
         f"Pre: {new_prefilter_data}, Elem: {create_elements}, for {feature} in {country_code}"
     )
@@ -302,8 +301,7 @@ def lonlat_lookup(df_way, Data):
         # df_way[col] = pd.Series([], dtype=pd.StringDtype()).astype(float)  # create empty "refs" if not in dataframe
 
     def look(ref):
-        lonlat_row = list(
-            map(lambda r: tuple(Data["Node"][str(r)]["lonlat"]), ref))
+        lonlat_row = list(map(lambda r: tuple(Data["Node"][str(r)]["lonlat"]), ref))
         return lonlat_row
 
     lonlat_list = df_way["refs"].apply(look)
@@ -318,19 +316,22 @@ def convert_ways_points(df_way, Data):
     lonlat_list = lonlat_lookup(df_way, Data)
     way_polygon = list(
         map(
-            lambda lonlat: Polygon(lonlat)
-            if len(lonlat) >= 3 else Point(lonlat[0]),
+            lambda lonlat: Polygon(lonlat) if len(lonlat) >= 3 else Point(lonlat[0]),
             lonlat_list,
-        ))
+        )
+    )
     area_column = list(
         map(
             int,
             round(
-                gpd.GeoSeries(way_polygon).set_crs("EPSG:4326").to_crs(
-                    "EPSG:3857").area,
+                gpd.GeoSeries(way_polygon)
+                .set_crs("EPSG:4326")
+                .to_crs("EPSG:3857")
+                .area,
                 -1,
             ),
-        ))  # TODO: Rounding should be down in cleaning scripts
+        )
+    )  # TODO: Rounding should be down in cleaning scripts
 
     def find_center_point(p):
         if p.geom_type == "Polygon":
@@ -355,8 +356,9 @@ def convert_ways_lines(df_way, Data):
     df_way.insert(0, "lonlat", lonlat_column)
 
     way_linestring = map(lambda lonlats: LineString(lonlats), lonlat_list)
-    length_column = (gpd.GeoSeries(way_linestring).set_crs("EPSG:4326").to_crs(
-        "EPSG:3857").length)
+    length_column = (
+        gpd.GeoSeries(way_linestring).set_crs("EPSG:4326").to_crs("EPSG:3857").length
+    )
 
     df_way.insert(0, "Length", length_column)
 
@@ -365,9 +367,9 @@ def convert_ways_lines(df_way, Data):
 
 
 def convert_pd_to_gdf_nodes(df_way):
-    gdf = gpd.GeoDataFrame(df_way,
-                           geometry=[Point(x, y) for x, y in df_way.lonlat],
-                           crs="EPSG:4326")
+    gdf = gpd.GeoDataFrame(
+        df_way, geometry=[Point(x, y) for x, y in df_way.lonlat], crs="EPSG:4326"
+    )
     gdf.drop(columns=["lonlat"], inplace=True)
     return gdf
 
@@ -379,18 +381,17 @@ def convert_pd_to_gdf_lines(df_way, simplified=False):
     # df_way["geometry"] = df_way["lonlat"].apply(lambda x: LineString(x))
     if simplified is True:
         df_way["geometry"] = df_way["geometry"].apply(
-            lambda x: x.simplify(0.005, preserve_topology=False))
-    gdf = gpd.GeoDataFrame(df_way,
-                           geometry=[LineString(x) for x in df_way.lonlat],
-                           crs="EPSG:4326")
+            lambda x: x.simplify(0.005, preserve_topology=False)
+        )
+    gdf = gpd.GeoDataFrame(
+        df_way, geometry=[LineString(x) for x in df_way.lonlat], crs="EPSG:4326"
+    )
     gdf.drop(columns=["lonlat"], inplace=True)
 
     return gdf
 
 
-def convert_iso_to_geofk(iso_code,
-                         iso_coding=True,
-                         convert_dict=iso_to_geofk_dict):
+def convert_iso_to_geofk(iso_code, iso_coding=True, convert_dict=iso_to_geofk_dict):
     """Function to convert the iso code name of a country into the corresponding geofabrik"""
     if iso_code in convert_dict:
         if not iso_coding:
@@ -406,16 +407,18 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
     "Function to save the feature as csv and geojson"
 
     continent, country_name = getContinentCountry(country_code)
-    outputfile_partial = os.path.join(os.getcwd(), "data", "raw",
-                                      continent + "_all"
-                                      "_raw")  # Output file directory
+    outputfile_partial = os.path.join(
+        os.getcwd(), "data", "raw", continent + "_all" "_raw"
+    )  # Output file directory
 
     if not os.path.exists(outputfile_partial):
-        os.makedirs(os.path.dirname(outputfile_partial),
-                    exist_ok=True)  # create raw directory
+        os.makedirs(
+            os.path.dirname(outputfile_partial), exist_ok=True
+        )  # create raw directory
 
-    df_all_feature = df_all_feature[df_all_feature.columns.intersection(
-        set(columns_feature))]
+    df_all_feature = df_all_feature[
+        df_all_feature.columns.intersection(set(columns_feature))
+    ]
     df_all_feature.reset_index(drop=True, inplace=True)
 
     # Generate Files
@@ -424,8 +427,9 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
         _logger.warning(f"All feature data frame empty for {feature}")
         return None
 
-    _to_csv_nafix(df_all_feature,
-                  outputfile_partial + f"_{feature}s" + ".csv")  # Generate CSV
+    _to_csv_nafix(
+        df_all_feature, outputfile_partial + f"_{feature}s" + ".csv"
+    )  # Generate CSV
 
     if feature_category[feature] == "way":
         gdf_feature = convert_pd_to_gdf_lines(df_all_feature)
@@ -433,8 +437,9 @@ def output_csv_geojson(country_code, df_all_feature, columns_feature, feature):
         gdf_feature = convert_pd_to_gdf_nodes(df_all_feature)
 
     _logger.info("Writing GeoJSON file")
-    gdf_feature.to_file(outputfile_partial + f"_{feature}s" + ".geojson",
-                        driver="GeoJSON")  # Generate GeoJson
+    gdf_feature.to_file(
+        outputfile_partial + f"_{feature}s" + ".geojson", driver="GeoJSON"
+    )  # Generate GeoJson
 
 
 def process_data(country_list, iso_coding=True, update=False, verify=False):
@@ -449,19 +454,20 @@ def process_data(country_list, iso_coding=True, update=False, verify=False):
         df_all_feature = pd.DataFrame()
         for country_code_isogeofk in country_list:
 
-            country_code = convert_iso_to_geofk(country_code_isogeofk,
-                                                iso_coding)
+            country_code = convert_iso_to_geofk(country_code_isogeofk, iso_coding)
 
-            feature_data = download_and_filter(feature, country_code, update,
-                                               verify)
+            feature_data = download_and_filter(feature, country_code, update, verify)
 
             df_node, df_way, Data = convert_filtered_data_to_dfs(
-                country_code, feature_data, feature)
+                country_code, feature_data, feature
+            )
 
             if feature_category[feature] == "way":
                 convert_ways_lines(
-                    df_way, Data) if not df_way.empty else _logger.warning(
-                        f"Empty Way Dataframe for {feature} in {country_code}")
+                    df_way, Data
+                ) if not df_way.empty else _logger.warning(
+                    f"Empty Way Dataframe for {feature} in {country_code}"
+                )
                 if not df_node.empty:
                     _logger.warning(
                         f"Node dataframe not empty for {feature} in {country_code}"
@@ -482,8 +488,9 @@ def process_data(country_list, iso_coding=True, update=False, verify=False):
 
             df_all_feature = pd.concat([df_all_feature, df_feature])
 
-        output_csv_geojson(country_code, df_all_feature,
-                           feature_columns[feature], feature)
+        output_csv_geojson(
+            country_code, df_all_feature, feature_columns[feature], feature
+        )
 
 
 def create_country_list(input, iso_coding=True):
@@ -507,6 +514,7 @@ def create_country_list(input, iso_coding=True):
     full_codes_list : list
         Example ["NG","ZA"]
     """
+
     def filter_codes(c_list, iso_coding=True):
         """
         Filter list according to the specified coding.

--- a/scripts/osm_pbf_power_data_extractor.py
+++ b/scripts/osm_pbf_power_data_extractor.py
@@ -554,6 +554,8 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
         snakemake = mock_snakemake("download_osm_data")
     configure_logging(snakemake)
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: : 2017-2020 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT
-
 # coding: utf-8
 """
 Prepare PyPSA network for solving according to :ref:`opts` and :ref:`ll`, such as
@@ -54,7 +53,6 @@ Description
     the rule :mod:`prepare_network`.
 
 """
-
 import logging
 import os
 import re
@@ -63,7 +61,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import load_costs, update_transmission_costs
+from add_electricity import load_costs
+from add_electricity import update_transmission_costs
 
 idx = pd.IndexSlice
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -90,13 +90,12 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
         emission_prices = snakemake.config["costs"]["emission_prices"]
     if exclude_co2:
         emission_prices.pop("co2")
-    ep = (
-        pd.Series(emission_prices).rename(lambda x: x + "_emissions")
-        * n.carriers.filter(like="_emissions")
-    ).sum(axis=1)
+    ep = (pd.Series(emission_prices).rename(lambda x: x + "_emissions") *
+          n.carriers.filter(like="_emissions")).sum(axis=1)
     gen_ep = n.generators.carrier.map(ep) / n.generators.efficiency
     n.generators["marginal_cost"] += gen_ep
-    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency_dispatch
+    su_ep = n.storage_units.carrier.map(
+        ep) / n.storage_units.efficiency_dispatch
     n.storage_units["marginal_cost"] += su_ep
 
 
@@ -109,19 +108,13 @@ def set_line_s_max_pu(n):
 def set_transmission_limit(n, ll_type, factor, Nyears=1):
     links_dc_b = n.links.carrier == "DC" if not n.links.empty else pd.Series()
 
-    _lines_s_nom = (
-        np.sqrt(3)
-        * n.lines.type.map(n.line_types.i_nom)
-        * n.lines.num_parallel
-        * n.lines.bus0.map(n.buses.v_nom)
-    )
+    _lines_s_nom = (np.sqrt(3) * n.lines.type.map(n.line_types.i_nom) *
+                    n.lines.num_parallel * n.lines.bus0.map(n.buses.v_nom))
     lines_s_nom = n.lines.s_nom.where(n.lines.type == "", _lines_s_nom)
 
     col = "capital_cost" if ll_type == "c" else "length"
-    ref = (
-        lines_s_nom @ n.lines[col]
-        + n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col]
-    )
+    ref = (lines_s_nom @ n.lines[col] +
+           n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col])
 
     costs = load_costs(
         Nyears,
@@ -175,9 +168,8 @@ def apply_time_segmentation(n, segments):
     try:
         import tsam.timeseriesaggregation as tsam
     except:
-        raise ModuleNotFoundError(
-            "Optional dependency 'tsam' not found." "Install via 'pip install tsam'"
-        )
+        raise ModuleNotFoundError("Optional dependency 'tsam' not found."
+                                  "Install via 'pip install tsam'")
 
     p_max_pu_norm = n.generators_t.p_max_pu.max()
     p_max_pu = n.generators_t.p_max_pu / p_max_pu_norm
@@ -205,29 +197,32 @@ def apply_time_segmentation(n, segments):
 
     weightings = segmented.index.get_level_values("Segment Duration")
     offsets = np.insert(np.cumsum(weightings[:-1]), 0, 0)
-    snapshots = [n.snapshots[0] + pd.Timedelta(f"{offset}h") for offset in offsets]
+    snapshots = [
+        n.snapshots[0] + pd.Timedelta(f"{offset}h") for offset in offsets
+    ]
 
     n.set_snapshots(pd.DatetimeIndex(snapshots, name="name"))
-    n.snapshot_weightings = pd.Series(
-        weightings, index=snapshots, name="weightings", dtype="float64"
-    )
+    n.snapshot_weightings = pd.Series(weightings,
+                                      index=snapshots,
+                                      name="weightings",
+                                      dtype="float64")
 
     segmented.index = snapshots
-    n.generators_t.p_max_pu = segmented[n.generators_t.p_max_pu.columns] * p_max_pu_norm
+    n.generators_t.p_max_pu = segmented[
+        n.generators_t.p_max_pu.columns] * p_max_pu_norm
     n.loads_t.p_set = segmented[n.loads_t.p_set.columns] * load_norm
-    n.storage_units_t.inflow = segmented[n.storage_units_t.inflow.columns] * inflow_norm
+    n.storage_units_t.inflow = segmented[
+        n.storage_units_t.inflow.columns] * inflow_norm
 
     return n
 
 
 def enforce_autarky(n, only_crossborder=False):
     if only_crossborder:
-        lines_rm = n.lines.loc[
-            n.lines.bus0.map(n.buses.country) != n.lines.bus1.map(n.buses.country)
-        ].index
-        links_rm = n.links.loc[
-            n.links.bus0.map(n.buses.country) != n.links.bus1.map(n.buses.country)
-        ].index
+        lines_rm = n.lines.loc[n.lines.bus0.map(n.buses.country) !=
+                               n.lines.bus1.map(n.buses.country)].index
+        links_rm = n.links.loc[n.links.bus0.map(n.buses.country) !=
+                               n.links.bus1.map(n.buses.country)].index
     else:
         lines_rm = n.lines.index
         links_rm = n.links.loc[n.links.carrier == "DC"].index

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -57,13 +57,12 @@ Description
 
 import logging
 import os
-from _helpers import configure_logging
-
 import re
-import pypsa
+
 import numpy as np
 import pandas as pd
-
+import pypsa
+from _helpers import configure_logging
 from add_electricity import load_costs, update_transmission_costs
 
 idx = pd.IndexSlice

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -71,67 +71,86 @@ idx = pd.IndexSlice
 logger = logging.getLogger(__name__)
 
 
-def add_co2limit(n, Nyears=1., factor=None):
+def add_co2limit(n, Nyears=1.0, factor=None):
 
     if factor is not None:
-        annual_emissions = factor*snakemake.config['electricity']['co2base']
+        annual_emissions = factor * snakemake.config["electricity"]["co2base"]
     else:
-        annual_emissions = snakemake.config['electricity']['co2limit']
+        annual_emissions = snakemake.config["electricity"]["co2limit"]
 
-    n.add("GlobalConstraint", "CO2Limit",
-          carrier_attribute="co2_emissions", sense="<=",
-          constant=annual_emissions * Nyears)
+    n.add(
+        "GlobalConstraint",
+        "CO2Limit",
+        carrier_attribute="co2_emissions",
+        sense="<=",
+        constant=annual_emissions * Nyears,
+    )
 
 
 def add_emission_prices(n, emission_prices=None, exclude_co2=False):
     if emission_prices is None:
-        emission_prices = snakemake.config['costs']['emission_prices']
+        emission_prices = snakemake.config["costs"]["emission_prices"]
     if exclude_co2:
-        emission_prices.pop('co2')
-    ep = (pd.Series(emission_prices).rename(lambda x: x+'_emissions') *
-          n.carriers.filter(like='_emissions')).sum(axis=1)
+        emission_prices.pop("co2")
+    ep = (
+        pd.Series(emission_prices).rename(lambda x: x + "_emissions")
+        * n.carriers.filter(like="_emissions")
+    ).sum(axis=1)
     gen_ep = n.generators.carrier.map(ep) / n.generators.efficiency
-    n.generators['marginal_cost'] += gen_ep
-    su_ep = n.storage_units.carrier.map(
-        ep) / n.storage_units.efficiency_dispatch
-    n.storage_units['marginal_cost'] += su_ep
+    n.generators["marginal_cost"] += gen_ep
+    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency_dispatch
+    n.storage_units["marginal_cost"] += su_ep
 
 
 def set_line_s_max_pu(n):
-    s_max_pu = snakemake.config['lines']['s_max_pu']
-    n.lines['s_max_pu'] = s_max_pu
+    s_max_pu = snakemake.config["lines"]["s_max_pu"]
+    n.lines["s_max_pu"] = s_max_pu
     logger.info(f"N-1 security margin of lines set to {s_max_pu}")
 
 
 def set_transmission_limit(n, ll_type, factor, Nyears=1):
-    links_dc_b = n.links.carrier == 'DC' if not n.links.empty else pd.Series()
+    links_dc_b = n.links.carrier == "DC" if not n.links.empty else pd.Series()
 
-    _lines_s_nom = (np.sqrt(3) * n.lines.type.map(n.line_types.i_nom) *
-                    n.lines.num_parallel * n.lines.bus0.map(n.buses.v_nom))
-    lines_s_nom = n.lines.s_nom.where(n.lines.type == '', _lines_s_nom)
+    _lines_s_nom = (
+        np.sqrt(3)
+        * n.lines.type.map(n.line_types.i_nom)
+        * n.lines.num_parallel
+        * n.lines.bus0.map(n.buses.v_nom)
+    )
+    lines_s_nom = n.lines.s_nom.where(n.lines.type == "", _lines_s_nom)
 
-    col = 'capital_cost' if ll_type == 'c' else 'length'
-    ref = (lines_s_nom @ n.lines[col] +
-           n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col])
+    col = "capital_cost" if ll_type == "c" else "length"
+    ref = (
+        lines_s_nom @ n.lines[col]
+        + n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col]
+    )
 
-    costs = load_costs(Nyears, snakemake.input.tech_costs,
-                       snakemake.config['costs'],
-                       snakemake.config['electricity'])
+    costs = load_costs(
+        Nyears,
+        snakemake.input.tech_costs,
+        snakemake.config["costs"],
+        snakemake.config["electricity"],
+    )
     update_transmission_costs(n, costs, simple_hvdc_costs=False)
 
-    if factor == 'opt' or float(factor) > 1.0:
-        n.lines['s_nom_min'] = lines_s_nom
-        n.lines['s_nom_extendable'] = True
+    if factor == "opt" or float(factor) > 1.0:
+        n.lines["s_nom_min"] = lines_s_nom
+        n.lines["s_nom_extendable"] = True
 
-        n.links.loc[links_dc_b, 'p_nom_min'] = n.links.loc[links_dc_b, 'p_nom']
-        n.links.loc[links_dc_b, 'p_nom_extendable'] = True
+        n.links.loc[links_dc_b, "p_nom_min"] = n.links.loc[links_dc_b, "p_nom"]
+        n.links.loc[links_dc_b, "p_nom_extendable"] = True
 
-    if factor != 'opt':
-        con_type = 'expansion_cost' if ll_type == 'c' else 'volume_expansion'
+    if factor != "opt":
+        con_type = "expansion_cost" if ll_type == "c" else "volume_expansion"
         rhs = float(factor) * ref
-        n.add('GlobalConstraint', f'l{ll_type}_limit',
-              type=f'transmission_{con_type}_limit',
-              sense='<=', constant=rhs, carrier_attribute='AC, DC')
+        n.add(
+            "GlobalConstraint",
+            f"l{ll_type}_limit",
+            type=f"transmission_{con_type}_limit",
+            sense="<=",
+            constant=rhs,
+            carrier_attribute="AC, DC",
+        )
 
     return n
 
@@ -145,7 +164,7 @@ def average_every_nhours(n, offset):
     m.snapshot_weightings = snapshot_weightings
 
     for c in n.iterate_components():
-        pnl = getattr(m, c.list_name+"_t")
+        pnl = getattr(m, c.list_name + "_t")
         for k, df in c.pnl.items():
             if not df.empty:
                 pnl[k] = df.resample(offset).mean()
@@ -158,8 +177,9 @@ def apply_time_segmentation(n, segments):
     try:
         import tsam.timeseriesaggregation as tsam
     except:
-        raise ModuleNotFoundError("Optional dependency 'tsam' not found."
-                                  "Install via 'pip install tsam'")
+        raise ModuleNotFoundError(
+            "Optional dependency 'tsam' not found." "Install via 'pip install tsam'"
+        )
 
     p_max_pu_norm = n.generators_t.p_max_pu.max()
     p_max_pu = n.generators_t.p_max_pu / p_max_pu_norm
@@ -174,20 +194,25 @@ def apply_time_segmentation(n, segments):
 
     solver_name = snakemake.config["solving"]["solver"]["name"]
 
-    agg = tsam.TimeSeriesAggregation(raw, hoursPerPeriod=len(raw),
-                                     noTypicalPeriods=1, noSegments=int(segments),
-                                     segmentation=True, solver=solver_name)
+    agg = tsam.TimeSeriesAggregation(
+        raw,
+        hoursPerPeriod=len(raw),
+        noTypicalPeriods=1,
+        noSegments=int(segments),
+        segmentation=True,
+        solver=solver_name,
+    )
 
     segmented = agg.createTypicalPeriods()
 
     weightings = segmented.index.get_level_values("Segment Duration")
     offsets = np.insert(np.cumsum(weightings[:-1]), 0, 0)
-    snapshots = [n.snapshots[0] +
-                 pd.Timedelta(f"{offset}h") for offset in offsets]
+    snapshots = [n.snapshots[0] + pd.Timedelta(f"{offset}h") for offset in offsets]
 
-    n.set_snapshots(pd.DatetimeIndex(snapshots, name='name'))
+    n.set_snapshots(pd.DatetimeIndex(snapshots, name="name"))
     n.snapshot_weightings = pd.Series(
-        weightings, index=snapshots, name="weightings", dtype="float64")
+        weightings, index=snapshots, name="weightings", dtype="float64"
+    )
 
     segmented.index = snapshots
     n.generators_t.p_max_pu = segmented[n.generators_t.p_max_pu.columns] * p_max_pu_norm
@@ -200,12 +225,10 @@ def apply_time_segmentation(n, segments):
 def enforce_autarky(n, only_crossborder=False):
     if only_crossborder:
         lines_rm = n.lines.loc[
-            n.lines.bus0.map(n.buses.country) !=
-            n.lines.bus1.map(n.buses.country)
+            n.lines.bus0.map(n.buses.country) != n.lines.bus1.map(n.buses.country)
         ].index
         links_rm = n.links.loc[
-            n.links.bus0.map(n.buses.country) !=
-            n.links.bus1.map(n.buses.country)
+            n.links.bus0.map(n.buses.country) != n.links.bus1.map(n.buses.country)
         ].index
     else:
         lines_rm = n.lines.index
@@ -222,28 +245,35 @@ def set_line_nom_max(n):
 
 
 if __name__ == "__main__":
-    if 'snakemake' not in globals():
+    if "snakemake" not in globals():
         from _helpers import mock_snakemake
+
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
-        snakemake = mock_snakemake('prepare_network', network='elec', simpl='',
-                                   clusters='10', ll='v0.3', opts='Co2L-24H')
+        snakemake = mock_snakemake(
+            "prepare_network",
+            network="elec",
+            simpl="",
+            clusters="10",
+            ll="v0.3",
+            opts="Co2L-24H",
+        )
     configure_logging(snakemake)
 
-    opts = snakemake.wildcards.opts.split('-')
+    opts = snakemake.wildcards.opts.split("-")
 
     n = pypsa.Network(snakemake.input[0])
-    Nyears = n.snapshot_weightings.objective.sum() / 8760.
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.0
 
     set_line_s_max_pu(n)
 
     for o in opts:
-        m = re.match(r'^\d+h$', o, re.IGNORECASE)
+        m = re.match(r"^\d+h$", o, re.IGNORECASE)
         if m is not None:
             n = average_every_nhours(n, m.group(0))
             break
 
     for o in opts:
-        m = re.match(r'^\d+seg$', o, re.IGNORECASE)
+        m = re.match(r"^\d+seg$", o, re.IGNORECASE)
         if m is not None:
             n = apply_time_segmentation(n, m.group(0)[:-3])
             break
@@ -274,7 +304,7 @@ if __name__ == "__main__":
                     sel = c.df.carrier.str.contains(carrier)
                     c.df.loc[sel, attr] *= factor
 
-    if 'Ep' in opts:
+    if "Ep" in opts:
         add_emission_prices(n)
 
     ll_type, factor = snakemake.wildcards.ll[0], snakemake.wildcards.ll[1:]

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -90,12 +90,13 @@ def add_emission_prices(n, emission_prices=None, exclude_co2=False):
         emission_prices = snakemake.config["costs"]["emission_prices"]
     if exclude_co2:
         emission_prices.pop("co2")
-    ep = (pd.Series(emission_prices).rename(lambda x: x + "_emissions") *
-          n.carriers.filter(like="_emissions")).sum(axis=1)
+    ep = (
+        pd.Series(emission_prices).rename(lambda x: x + "_emissions")
+        * n.carriers.filter(like="_emissions")
+    ).sum(axis=1)
     gen_ep = n.generators.carrier.map(ep) / n.generators.efficiency
     n.generators["marginal_cost"] += gen_ep
-    su_ep = n.storage_units.carrier.map(
-        ep) / n.storage_units.efficiency_dispatch
+    su_ep = n.storage_units.carrier.map(ep) / n.storage_units.efficiency_dispatch
     n.storage_units["marginal_cost"] += su_ep
 
 
@@ -108,13 +109,19 @@ def set_line_s_max_pu(n):
 def set_transmission_limit(n, ll_type, factor, Nyears=1):
     links_dc_b = n.links.carrier == "DC" if not n.links.empty else pd.Series()
 
-    _lines_s_nom = (np.sqrt(3) * n.lines.type.map(n.line_types.i_nom) *
-                    n.lines.num_parallel * n.lines.bus0.map(n.buses.v_nom))
+    _lines_s_nom = (
+        np.sqrt(3)
+        * n.lines.type.map(n.line_types.i_nom)
+        * n.lines.num_parallel
+        * n.lines.bus0.map(n.buses.v_nom)
+    )
     lines_s_nom = n.lines.s_nom.where(n.lines.type == "", _lines_s_nom)
 
     col = "capital_cost" if ll_type == "c" else "length"
-    ref = (lines_s_nom @ n.lines[col] +
-           n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col])
+    ref = (
+        lines_s_nom @ n.lines[col]
+        + n.links.loc[links_dc_b, "p_nom"] @ n.links.loc[links_dc_b, col]
+    )
 
     costs = load_costs(
         Nyears,
@@ -168,8 +175,9 @@ def apply_time_segmentation(n, segments):
     try:
         import tsam.timeseriesaggregation as tsam
     except:
-        raise ModuleNotFoundError("Optional dependency 'tsam' not found."
-                                  "Install via 'pip install tsam'")
+        raise ModuleNotFoundError(
+            "Optional dependency 'tsam' not found." "Install via 'pip install tsam'"
+        )
 
     p_max_pu_norm = n.generators_t.p_max_pu.max()
     p_max_pu = n.generators_t.p_max_pu / p_max_pu_norm
@@ -197,32 +205,29 @@ def apply_time_segmentation(n, segments):
 
     weightings = segmented.index.get_level_values("Segment Duration")
     offsets = np.insert(np.cumsum(weightings[:-1]), 0, 0)
-    snapshots = [
-        n.snapshots[0] + pd.Timedelta(f"{offset}h") for offset in offsets
-    ]
+    snapshots = [n.snapshots[0] + pd.Timedelta(f"{offset}h") for offset in offsets]
 
     n.set_snapshots(pd.DatetimeIndex(snapshots, name="name"))
-    n.snapshot_weightings = pd.Series(weightings,
-                                      index=snapshots,
-                                      name="weightings",
-                                      dtype="float64")
+    n.snapshot_weightings = pd.Series(
+        weightings, index=snapshots, name="weightings", dtype="float64"
+    )
 
     segmented.index = snapshots
-    n.generators_t.p_max_pu = segmented[
-        n.generators_t.p_max_pu.columns] * p_max_pu_norm
+    n.generators_t.p_max_pu = segmented[n.generators_t.p_max_pu.columns] * p_max_pu_norm
     n.loads_t.p_set = segmented[n.loads_t.p_set.columns] * load_norm
-    n.storage_units_t.inflow = segmented[
-        n.storage_units_t.inflow.columns] * inflow_norm
+    n.storage_units_t.inflow = segmented[n.storage_units_t.inflow.columns] * inflow_norm
 
     return n
 
 
 def enforce_autarky(n, only_crossborder=False):
     if only_crossborder:
-        lines_rm = n.lines.loc[n.lines.bus0.map(n.buses.country) !=
-                               n.lines.bus1.map(n.buses.country)].index
-        links_rm = n.links.loc[n.links.bus0.map(n.buses.country) !=
-                               n.links.bus1.map(n.buses.country)].index
+        lines_rm = n.lines.loc[
+            n.lines.bus0.map(n.buses.country) != n.lines.bus1.map(n.buses.country)
+        ].index
+        links_rm = n.links.loc[
+            n.links.bus0.map(n.buses.country) != n.links.bus1.map(n.buses.country)
+        ].index
     else:
         lines_rm = n.lines.index
         links_rm = n.links.loc[n.links.carrier == "DC"].index

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -56,6 +56,7 @@ Description
 """
 
 import logging
+import os
 from _helpers import configure_logging
 
 import re
@@ -217,8 +218,9 @@ def set_line_nom_max(n):
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from _helpers import mock_snakemake
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake('prepare_network', network='elec', simpl='',
-                                  clusters='40', ll='v0.3', opts='Co2L-24H')
+                                  clusters='10', ll='v0.3', opts='Co2L-24H')
     configure_logging(snakemake)
 
     opts = snakemake.wildcards.opts.split('-')

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -61,7 +61,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import load_costs, update_transmission_costs
+from add_electricity import load_costs
+from add_electricity import update_transmission_costs
 
 idx = pd.IndexSlice
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -61,8 +61,7 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from add_electricity import load_costs
-from add_electricity import update_transmission_costs
+from add_electricity import load_costs, update_transmission_costs
 
 idx = pd.IndexSlice
 

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -35,7 +35,9 @@ import os
 import tarfile
 from pathlib import Path
 
-from _helpers import _sets_path_to_root, configure_logging, progress_retrieve
+from _helpers import _sets_path_to_root
+from _helpers import configure_logging
+from _helpers import progress_retrieve
 from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -35,9 +35,7 @@ import os
 import tarfile
 from pathlib import Path
 
-from _helpers import _sets_path_to_root
-from _helpers import configure_logging
-from _helpers import progress_retrieve
+from _helpers import _sets_path_to_root, configure_logging, progress_retrieve
 from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if 'snakemake' not in globals():
-        
+
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
         from _helpers import mock_snakemake
@@ -53,14 +53,14 @@ if __name__ == "__main__":
         rootpath = '..'
     else:
         rootpath = '.'
-    configure_logging(snakemake) # TODO Make logging compatible with progressbar (see PR #102)
+    # TODO Make logging compatible with progressbar (see PR #102)
+    configure_logging(snakemake)
 
     _sets_path_to_root("pypsa-africa")
 
-
     # BUNDLE 1
     destination = './resources'
-    zip_path = destination +'.zip'
+    zip_path = destination + '.zip'
     url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
     gdd.download_file_from_google_drive(file_id='1nrWntieUVUcyya0xaadt4T3JFTDrqhLf',
                                         dest_path=zip_path,
@@ -68,10 +68,9 @@ if __name__ == "__main__":
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
-
     # BUNDLE 2
     destination = './data'
-    zip_path = destination +'.zip'
+    zip_path = destination + '.zip'
     url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
     gdd.download_file_from_google_drive(file_id='1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ',
                                         dest_path=zip_path,
@@ -79,10 +78,9 @@ if __name__ == "__main__":
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
-
     # BUNDLE 3
     destination = './cutouts'
-    zip_path = destination +'.zip'
+    zip_path = destination + '.zip'
     url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
     gdd.download_file_from_google_drive(file_id='1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O',
                                         dest_path=zip_path,

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -61,8 +61,8 @@ if __name__ == "__main__":
     # BUNDLE 1
     destination = './resources'
     zip_path = destination +'.zip'
-    url = "https://drive.google.com/file/d/1L5ewMn2i0iscYCeKAHpPFWyux8J6ld4B/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1L5ewMn2i0iscYCeKAHpPFWyux8J6ld4B',
+    url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
+    gdd.download_file_from_google_drive(file_id='1nrWntieUVUcyya0xaadt4T3JFTDrqhLf',
                                         dest_path=zip_path,
                                         unzip=True)
     os.remove(zip_path)
@@ -72,8 +72,8 @@ if __name__ == "__main__":
     # BUNDLE 2
     destination = './data'
     zip_path = destination +'.zip'
-    url = "https://drive.google.com/file/d/1F0UQz0nenMgIAeIYWQZJ18UJCG-tcfGl/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1F0UQz0nenMgIAeIYWQZJ18UJCG-tcfGl',
+    url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
+    gdd.download_file_from_google_drive(file_id='1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ',
                                         dest_path=zip_path,
                                         unzip=True)
     os.remove(zip_path)
@@ -83,8 +83,8 @@ if __name__ == "__main__":
     # BUNDLE 3
     destination = './cutouts'
     zip_path = destination +'.zip'
-    url = "https://drive.google.com/file/d/1rCIylwHJ-JLQF5ZDquSyYlaLkWdPORUb/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1rCIylwHJ-JLQF5ZDquSyYlaLkWdPORUb',
+    url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
+    gdd.download_file_from_google_drive(file_id='1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O',
                                         dest_path=zip_path,
                                         unzip=True)
     os.remove(zip_path)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -34,11 +34,11 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 
 import logging
 import os
-from _helpers import progress_retrieve, configure_logging
-from google_drive_downloader import GoogleDriveDownloader as gdd
 import tarfile
 from pathlib import Path
-from _helpers import _sets_path_to_root
+
+from _helpers import _sets_path_to_root, configure_logging, progress_retrieve
+from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -42,7 +42,6 @@ from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)
 
-
 if __name__ == "__main__":
     if "snakemake" not in globals():
 
@@ -64,8 +63,9 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf", dest_path=zip_path, unzip=True
-    )
+        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -74,8 +74,9 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ", dest_path=zip_path, unzip=True
-    )
+        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -84,7 +85,8 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O", dest_path=zip_path, unzip=True
-    )
+        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -63,9 +63,8 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf",
-        dest_path=zip_path,
-        unzip=True)
+        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -74,9 +73,8 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ",
-        dest_path=zip_path,
-        unzip=True)
+        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -85,8 +83,7 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O",
-        dest_path=zip_path,
-        unzip=True)
+        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -44,46 +44,47 @@ logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
-    if 'snakemake' not in globals():
+    if "snakemake" not in globals():
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
         from _helpers import mock_snakemake
-        snakemake = mock_snakemake('retrieve_databundle_light')
-        rootpath = '..'
+
+        snakemake = mock_snakemake("retrieve_databundle_light")
+        rootpath = ".."
     else:
-        rootpath = '.'
+        rootpath = "."
     # TODO Make logging compatible with progressbar (see PR #102)
     configure_logging(snakemake)
 
     _sets_path_to_root("pypsa-africa")
 
     # BUNDLE 1
-    destination = './resources'
-    zip_path = destination + '.zip'
+    destination = "./resources"
+    zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1nrWntieUVUcyya0xaadt4T3JFTDrqhLf',
-                                        dest_path=zip_path,
-                                        unzip=True)
+    gdd.download_file_from_google_drive(
+        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
     # BUNDLE 2
-    destination = './data'
-    zip_path = destination + '.zip'
+    destination = "./data"
+    zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ',
-                                        dest_path=zip_path,
-                                        unzip=True)
+    gdd.download_file_from_google_drive(
+        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
     # BUNDLE 3
-    destination = './cutouts'
-    zip_path = destination + '.zip'
+    destination = "./cutouts"
+    zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
-    gdd.download_file_from_google_drive(file_id='1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O',
-                                        dest_path=zip_path,
-                                        unzip=True)
+    gdd.download_file_from_google_drive(
+        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O", dest_path=zip_path, unzip=True
+    )
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: : 2017-2020 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT
-
 """
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3517935.svg
    :target: https://doi.org/10.5281/zenodo.3517935
@@ -31,13 +30,14 @@ The :ref:`tutorial` uses a smaller `data bundle <https://zenodo.org/record/35179
 - ``cutouts/bundle``: input data collected from various sources
 
 """
-
 import logging
 import os
 import tarfile
 from pathlib import Path
 
-from _helpers import _sets_path_to_root, configure_logging, progress_retrieve
+from _helpers import _sets_path_to_root
+from _helpers import configure_logging
+from _helpers import progress_retrieve
 from google_drive_downloader import GoogleDriveDownloader as gdd
 
 logger = logging.getLogger(__name__)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -63,8 +63,9 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1nrWntieUVUcyya0xaadt4T3JFTDrqhLf/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf", dest_path=zip_path, unzip=True
-    )
+        file_id="1nrWntieUVUcyya0xaadt4T3JFTDrqhLf",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -73,8 +74,9 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ", dest_path=zip_path, unzip=True
-    )
+        file_id="1IfSofV2PWUkAD_7yY-Xqv1X4duma2NkJ",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")
 
@@ -83,7 +85,8 @@ if __name__ == "__main__":
     zip_path = destination + ".zip"
     url = "https://drive.google.com/file/d/1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O/view?usp=sharing"
     gdd.download_file_from_google_drive(
-        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O", dest_path=zip_path, unzip=True
-    )
+        file_id="1kyOH8wxm_cvnS7OoahCrFFVP-U7kWr_O",
+        dest_path=zip_path,
+        unzip=True)
     os.remove(zip_path)
     logger.info(f"Download data to '{destination}' from cloud '{url}'.")

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: : 2017-2020 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT
-
 """
 Solves linear optimal power flow for a network iteratively while updating reactances.
 
@@ -75,7 +74,6 @@ Details (and errors made through this heuristic) are discussed in the paper
     the rule :mod:`solve_network`.
 
 """
-
 import logging
 import os
 import re
@@ -85,8 +83,12 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from pypsa.linopf import (define_constraints, get_var, ilopf, join_exprs,
-                          linexpr, network_lopf)
+from pypsa.linopf import define_constraints
+from pypsa.linopf import get_var
+from pypsa.linopf import ilopf
+from pypsa.linopf import join_exprs
+from pypsa.linopf import linexpr
+from pypsa.linopf import network_lopf
 from vresutils.benchmark import memory_logger
 
 logger = logging.getLogger(__name__)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -123,13 +123,12 @@ def prepare_network(n, solve_opts):
             #    t.df['capital_cost'] += 1e1 + 2.*(np.random.random(len(t.df)) - 0.5)
             if "marginal_cost" in t.df:
                 t.df["marginal_cost"] += 1e-2 + 2e-3 * (
-                    np.random.random(len(t.df)) - 0.5
-                )
+                    np.random.random(len(t.df)) - 0.5)
 
         for t in n.iterate_components(["Line", "Link"]):
             t.df["capital_cost"] += (
-                1e-1 + 2e-2 * (np.random.random(len(t.df)) - 0.5)
-            ) * t.df["length"]
+                1e-1 + 2e-2 *
+                (np.random.random(len(t.df)) - 0.5)) * t.df["length"]
 
     if solve_opts.get("nhours"):
         nhours = solve_opts["nhours"]
@@ -143,41 +142,34 @@ def add_CCL_constraints(n, config):
     agg_p_nom_limits = config["electricity"].get("agg_p_nom_limits")
 
     try:
-        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits, index_col=list(range(2)))
+        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits,
+                                       index_col=list(range(2)))
     except IOError:
-        logger.exception(
-            "Need to specify the path to a .csv file containing "
-            "aggregate capacity limits per country in "
-            "config['electricity']['agg_p_nom_limit']."
-        )
-    logger.info(
-        "Adding per carrier generation capacity constraints for " "individual countries"
-    )
+        logger.exception("Need to specify the path to a .csv file containing "
+                         "aggregate capacity limits per country in "
+                         "config['electricity']['agg_p_nom_limit'].")
+    logger.info("Adding per carrier generation capacity constraints for "
+                "individual countries")
 
     gen_country = n.generators.bus.map(n.buses.country)
     # cc means country and carrier
-    p_nom_per_cc = (
-        pd.DataFrame(
-            {
-                "p_nom": linexpr((1, get_var(n, "Generator", "p_nom"))),
-                "country": gen_country,
-                "carrier": n.generators.carrier,
-            }
-        )
-        .dropna(subset=["p_nom"])
-        .groupby(["country", "carrier"])
-        .p_nom.apply(join_exprs)
-    )
+    p_nom_per_cc = (pd.DataFrame({
+        "p_nom":
+        linexpr((1, get_var(n, "Generator", "p_nom"))),
+        "country":
+        gen_country,
+        "carrier":
+        n.generators.carrier,
+    }).dropna(subset=["p_nom"]).groupby(["country",
+                                         "carrier"]).p_nom.apply(join_exprs))
     minimum = agg_p_nom_minmax["min"].dropna()
     if not minimum.empty:
-        minconstraint = define_constraints(
-            n, p_nom_per_cc[minimum.index], ">=", minimum, "agg_p_nom", "min"
-        )
+        minconstraint = define_constraints(n, p_nom_per_cc[minimum.index],
+                                           ">=", minimum, "agg_p_nom", "min")
     maximum = agg_p_nom_minmax["max"].dropna()
     if not maximum.empty:
-        maxconstraint = define_constraints(
-            n, p_nom_per_cc[maximum.index], "<=", maximum, "agg_p_nom", "max"
-        )
+        maxconstraint = define_constraints(n, p_nom_per_cc[maximum.index],
+                                           "<=", maximum, "agg_p_nom", "max")
 
 
 def add_EQ_constraints(n, o, scaling=1e-1):
@@ -191,33 +183,20 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         ggrouper = n.generators.bus
         lgrouper = n.loads.bus
         sgrouper = n.storage_units.bus
-    load = (
-        n.snapshot_weightings.generators
-        @ n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
-    )
-    inflow = (
-        n.snapshot_weightings.stores
-        @ n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
-    )
+    load = (n.snapshot_weightings.generators @ n.loads_t.p_set.groupby(
+        lgrouper, axis=1).sum())
+    inflow = (n.snapshot_weightings.stores @ n.storage_units_t.inflow.groupby(
+        sgrouper, axis=1).sum())
     inflow = inflow.reindex(load.index).fillna(0.0)
     rhs = scaling * (level * load - inflow)
-    lhs_gen = (
-        linexpr(
-            (n.snapshot_weightings.generators * scaling, get_var(n, "Generator", "p").T)
-        )
-        .T.groupby(ggrouper, axis=1)
-        .apply(join_exprs)
-    )
-    lhs_spill = (
-        linexpr(
-            (
-                -n.snapshot_weightings.stores * scaling,
-                get_var(n, "StorageUnit", "spill").T,
-            )
-        )
-        .T.groupby(sgrouper, axis=1)
-        .apply(join_exprs)
-    )
+    lhs_gen = (linexpr((n.snapshot_weightings.generators * scaling,
+                        get_var(n, "Generator",
+                                "p").T)).T.groupby(ggrouper,
+                                                   axis=1).apply(join_exprs))
+    lhs_spill = (linexpr((
+        -n.snapshot_weightings.stores * scaling,
+        get_var(n, "StorageUnit", "spill").T,
+    )).T.groupby(sgrouper, axis=1).apply(join_exprs))
     lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
     lhs = lhs_gen + lhs_spill
     define_constraints(n, lhs, ">=", rhs, "equity", "min")
@@ -225,23 +204,21 @@ def add_EQ_constraints(n, o, scaling=1e-1):
 
 def add_BAU_constraints(n, config):
     mincaps = pd.Series(config["electricity"]["BAU_mincapacities"])
-    lhs = (
-        linexpr((1, get_var(n, "Generator", "p_nom")))
-        .groupby(n.generators.carrier)
-        .apply(join_exprs)
-    )
-    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier", "bau_mincaps")
+    lhs = (linexpr(
+        (1, get_var(n, "Generator",
+                    "p_nom"))).groupby(n.generators.carrier).apply(join_exprs))
+    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier",
+                       "bau_mincaps")
 
 
 def add_SAFE_constraints(n, config):
-    peakdemand = (
-        1.0 + config["electricity"]["SAFE_reservemargin"]
-    ) * n.loads_t.p_set.sum(axis=1).max()
+    peakdemand = (1.0 + config["electricity"]["SAFE_reservemargin"]
+                  ) * n.loads_t.p_set.sum(axis=1).max()
     conv_techs = config["plotting"]["conv_techs"]
     exist_conv_caps = n.generators.query(
-        "~p_nom_extendable & carrier in @conv_techs"
-    ).p_nom.sum()
-    ext_gens_i = n.generators.query("carrier in @conv_techs & p_nom_extendable").index
+        "~p_nom_extendable & carrier in @conv_techs").p_nom.sum()
+    ext_gens_i = n.generators.query(
+        "carrier in @conv_techs & p_nom_extendable").index
     lhs = linexpr((1, get_var(n, "Generator", "p_nom")[ext_gens_i])).sum()
     rhs = peakdemand - exist_conv_caps
     define_constraints(n, lhs, ">=", rhs, "Safe", "mintotalcap")
@@ -295,24 +272,20 @@ def solve_network(n, config, opts="", **kwargs):
     n.opts = opts
 
     if cf_solving.get("skip_iterations", False):
-        network_lopf(
-            n,
-            solver_name=solver_name,
-            solver_options=solver_options,
-            extra_functionality=extra_functionality,
-            **kwargs
-        )
+        network_lopf(n,
+                     solver_name=solver_name,
+                     solver_options=solver_options,
+                     extra_functionality=extra_functionality,
+                     **kwargs)
     else:
-        ilopf(
-            n,
-            solver_name=solver_name,
-            solver_options=solver_options,
-            track_iterations=track_iterations,
-            min_iterations=min_iterations,
-            max_iterations=max_iterations,
-            extra_functionality=extra_functionality,
-            **kwargs
-        )
+        ilopf(n,
+              solver_name=solver_name,
+              solver_options=solver_options,
+              track_iterations=track_iterations,
+              min_iterations=min_iterations,
+              max_iterations=max_iterations,
+              extra_functionality=extra_functionality,
+              **kwargs)
     return n
 
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -83,8 +83,12 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from pypsa.linopf import (define_constraints, get_var, ilopf, join_exprs,
-                          linexpr, network_lopf)
+from pypsa.linopf import define_constraints
+from pypsa.linopf import get_var
+from pypsa.linopf import ilopf
+from pypsa.linopf import join_exprs
+from pypsa.linopf import linexpr
+from pypsa.linopf import network_lopf
 from vresutils.benchmark import memory_logger
 
 logger = logging.getLogger(__name__)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -83,12 +83,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
-from pypsa.linopf import define_constraints
-from pypsa.linopf import get_var
-from pypsa.linopf import ilopf
-from pypsa.linopf import join_exprs
-from pypsa.linopf import linexpr
-from pypsa.linopf import network_lopf
+from pypsa.linopf import (define_constraints, get_var, ilopf, join_exprs,
+                          linexpr, network_lopf)
 from vresutils.benchmark import memory_logger
 
 logger = logging.getLogger(__name__)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -77,24 +77,16 @@ Details (and errors made through this heuristic) are discussed in the paper
 """
 
 import logging
-from _helpers import configure_logging
+import os
+import re
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import re
-import os
-
 import pypsa
-from pypsa.linopf import (
-    get_var,
-    define_constraints,
-    linexpr,
-    join_exprs,
-    network_lopf,
-    ilopf,
-)
-
-from pathlib import Path
+from _helpers import configure_logging
+from pypsa.linopf import (define_constraints, get_var, ilopf, join_exprs,
+                          linexpr, network_lopf)
 from vresutils.benchmark import memory_logger
 
 logger = logging.getLogger(__name__)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -123,12 +123,13 @@ def prepare_network(n, solve_opts):
             #    t.df['capital_cost'] += 1e1 + 2.*(np.random.random(len(t.df)) - 0.5)
             if "marginal_cost" in t.df:
                 t.df["marginal_cost"] += 1e-2 + 2e-3 * (
-                    np.random.random(len(t.df)) - 0.5)
+                    np.random.random(len(t.df)) - 0.5
+                )
 
         for t in n.iterate_components(["Line", "Link"]):
             t.df["capital_cost"] += (
-                1e-1 + 2e-2 *
-                (np.random.random(len(t.df)) - 0.5)) * t.df["length"]
+                1e-1 + 2e-2 * (np.random.random(len(t.df)) - 0.5)
+            ) * t.df["length"]
 
     if solve_opts.get("nhours"):
         nhours = solve_opts["nhours"]
@@ -142,34 +143,41 @@ def add_CCL_constraints(n, config):
     agg_p_nom_limits = config["electricity"].get("agg_p_nom_limits")
 
     try:
-        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits,
-                                       index_col=list(range(2)))
+        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits, index_col=list(range(2)))
     except IOError:
-        logger.exception("Need to specify the path to a .csv file containing "
-                         "aggregate capacity limits per country in "
-                         "config['electricity']['agg_p_nom_limit'].")
-    logger.info("Adding per carrier generation capacity constraints for "
-                "individual countries")
+        logger.exception(
+            "Need to specify the path to a .csv file containing "
+            "aggregate capacity limits per country in "
+            "config['electricity']['agg_p_nom_limit']."
+        )
+    logger.info(
+        "Adding per carrier generation capacity constraints for " "individual countries"
+    )
 
     gen_country = n.generators.bus.map(n.buses.country)
     # cc means country and carrier
-    p_nom_per_cc = (pd.DataFrame({
-        "p_nom":
-        linexpr((1, get_var(n, "Generator", "p_nom"))),
-        "country":
-        gen_country,
-        "carrier":
-        n.generators.carrier,
-    }).dropna(subset=["p_nom"]).groupby(["country",
-                                         "carrier"]).p_nom.apply(join_exprs))
+    p_nom_per_cc = (
+        pd.DataFrame(
+            {
+                "p_nom": linexpr((1, get_var(n, "Generator", "p_nom"))),
+                "country": gen_country,
+                "carrier": n.generators.carrier,
+            }
+        )
+        .dropna(subset=["p_nom"])
+        .groupby(["country", "carrier"])
+        .p_nom.apply(join_exprs)
+    )
     minimum = agg_p_nom_minmax["min"].dropna()
     if not minimum.empty:
-        minconstraint = define_constraints(n, p_nom_per_cc[minimum.index],
-                                           ">=", minimum, "agg_p_nom", "min")
+        minconstraint = define_constraints(
+            n, p_nom_per_cc[minimum.index], ">=", minimum, "agg_p_nom", "min"
+        )
     maximum = agg_p_nom_minmax["max"].dropna()
     if not maximum.empty:
-        maxconstraint = define_constraints(n, p_nom_per_cc[maximum.index],
-                                           "<=", maximum, "agg_p_nom", "max")
+        maxconstraint = define_constraints(
+            n, p_nom_per_cc[maximum.index], "<=", maximum, "agg_p_nom", "max"
+        )
 
 
 def add_EQ_constraints(n, o, scaling=1e-1):
@@ -183,20 +191,33 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         ggrouper = n.generators.bus
         lgrouper = n.loads.bus
         sgrouper = n.storage_units.bus
-    load = (n.snapshot_weightings.generators @ n.loads_t.p_set.groupby(
-        lgrouper, axis=1).sum())
-    inflow = (n.snapshot_weightings.stores @ n.storage_units_t.inflow.groupby(
-        sgrouper, axis=1).sum())
+    load = (
+        n.snapshot_weightings.generators
+        @ n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
+    )
+    inflow = (
+        n.snapshot_weightings.stores
+        @ n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
+    )
     inflow = inflow.reindex(load.index).fillna(0.0)
     rhs = scaling * (level * load - inflow)
-    lhs_gen = (linexpr((n.snapshot_weightings.generators * scaling,
-                        get_var(n, "Generator",
-                                "p").T)).T.groupby(ggrouper,
-                                                   axis=1).apply(join_exprs))
-    lhs_spill = (linexpr((
-        -n.snapshot_weightings.stores * scaling,
-        get_var(n, "StorageUnit", "spill").T,
-    )).T.groupby(sgrouper, axis=1).apply(join_exprs))
+    lhs_gen = (
+        linexpr(
+            (n.snapshot_weightings.generators * scaling, get_var(n, "Generator", "p").T)
+        )
+        .T.groupby(ggrouper, axis=1)
+        .apply(join_exprs)
+    )
+    lhs_spill = (
+        linexpr(
+            (
+                -n.snapshot_weightings.stores * scaling,
+                get_var(n, "StorageUnit", "spill").T,
+            )
+        )
+        .T.groupby(sgrouper, axis=1)
+        .apply(join_exprs)
+    )
     lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
     lhs = lhs_gen + lhs_spill
     define_constraints(n, lhs, ">=", rhs, "equity", "min")
@@ -204,21 +225,23 @@ def add_EQ_constraints(n, o, scaling=1e-1):
 
 def add_BAU_constraints(n, config):
     mincaps = pd.Series(config["electricity"]["BAU_mincapacities"])
-    lhs = (linexpr(
-        (1, get_var(n, "Generator",
-                    "p_nom"))).groupby(n.generators.carrier).apply(join_exprs))
-    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier",
-                       "bau_mincaps")
+    lhs = (
+        linexpr((1, get_var(n, "Generator", "p_nom")))
+        .groupby(n.generators.carrier)
+        .apply(join_exprs)
+    )
+    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier", "bau_mincaps")
 
 
 def add_SAFE_constraints(n, config):
-    peakdemand = (1.0 + config["electricity"]["SAFE_reservemargin"]
-                  ) * n.loads_t.p_set.sum(axis=1).max()
+    peakdemand = (
+        1.0 + config["electricity"]["SAFE_reservemargin"]
+    ) * n.loads_t.p_set.sum(axis=1).max()
     conv_techs = config["plotting"]["conv_techs"]
     exist_conv_caps = n.generators.query(
-        "~p_nom_extendable & carrier in @conv_techs").p_nom.sum()
-    ext_gens_i = n.generators.query(
-        "carrier in @conv_techs & p_nom_extendable").index
+        "~p_nom_extendable & carrier in @conv_techs"
+    ).p_nom.sum()
+    ext_gens_i = n.generators.query("carrier in @conv_techs & p_nom_extendable").index
     lhs = linexpr((1, get_var(n, "Generator", "p_nom")[ext_gens_i])).sum()
     rhs = peakdemand - exist_conv_caps
     define_constraints(n, lhs, ">=", rhs, "Safe", "mintotalcap")
@@ -272,20 +295,24 @@ def solve_network(n, config, opts="", **kwargs):
     n.opts = opts
 
     if cf_solving.get("skip_iterations", False):
-        network_lopf(n,
-                     solver_name=solver_name,
-                     solver_options=solver_options,
-                     extra_functionality=extra_functionality,
-                     **kwargs)
+        network_lopf(
+            n,
+            solver_name=solver_name,
+            solver_options=solver_options,
+            extra_functionality=extra_functionality,
+            **kwargs
+        )
     else:
-        ilopf(n,
-              solver_name=solver_name,
-              solver_options=solver_options,
-              track_iterations=track_iterations,
-              min_iterations=min_iterations,
-              max_iterations=max_iterations,
-              extra_functionality=extra_functionality,
-              **kwargs)
+        ilopf(
+            n,
+            solver_name=solver_name,
+            solver_options=solver_options,
+            track_iterations=track_iterations,
+            min_iterations=min_iterations,
+            max_iterations=max_iterations,
+            extra_functionality=extra_functionality,
+            **kwargs
+        )
     return n
 
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -82,6 +82,7 @@ from _helpers import configure_logging
 import numpy as np
 import pandas as pd
 import re
+import os
 
 import pypsa
 from pypsa.linopf import (get_var, define_constraints, linexpr, join_exprs,
@@ -269,8 +270,11 @@ def solve_network(n, config, opts='', **kwargs):
 if __name__ == "__main__":
     if 'snakemake' not in globals():
         from _helpers import mock_snakemake
+        
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
         snakemake = mock_snakemake('solve_network', network='elec', simpl='',
-                                  clusters='5', ll='copt', opts='Co2L-BAU-CCL-24H')
+                                  clusters='10', ll='v0.3', opts='Co2L-24H')
     configure_logging(snakemake)
 
     tmpdir = snakemake.config['solving'].get('tmpdir')

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -85,8 +85,14 @@ import re
 import os
 
 import pypsa
-from pypsa.linopf import (get_var, define_constraints, linexpr, join_exprs,
-                          network_lopf, ilopf)
+from pypsa.linopf import (
+    get_var,
+    define_constraints,
+    linexpr,
+    join_exprs,
+    network_lopf,
+    ilopf,
+)
 
 from pathlib import Path
 from vresutils.benchmark import memory_logger
@@ -96,79 +102,94 @@ logger = logging.getLogger(__name__)
 
 def prepare_network(n, solve_opts):
 
-    if 'clip_p_max_pu' in solve_opts:
+    if "clip_p_max_pu" in solve_opts:
         for df in (n.generators_t.p_max_pu, n.storage_units_t.inflow):
-            df.where(df > solve_opts['clip_p_max_pu'], other=0., inplace=True)
+            df.where(df > solve_opts["clip_p_max_pu"], other=0.0, inplace=True)
 
-    if solve_opts.get('load_shedding'):
+    if solve_opts.get("load_shedding"):
         n.add("Carrier", "Load")
         buses_i = n.buses.query("carrier == 'AC'").index
-        n.madd("Generator", buses_i, " load",
-               bus=buses_i,
-               carrier='load',
-               sign=1e-3,  # Adjust sign to measure p and p_nom in kW instead of MW
-               marginal_cost=1e2,  # Eur/kWh
-               # intersect between macroeconomic and surveybased
-               # willingness to pay
-               # http://journal.frontiersin.org/article/10.3389/fenrg.2015.00055/full
-               p_nom=1e9  # kW
-               )
+        n.madd(
+            "Generator",
+            buses_i,
+            " load",
+            bus=buses_i,
+            carrier="load",
+            sign=1e-3,  # Adjust sign to measure p and p_nom in kW instead of MW
+            marginal_cost=1e2,  # Eur/kWh
+            # intersect between macroeconomic and surveybased
+            # willingness to pay
+            # http://journal.frontiersin.org/article/10.3389/fenrg.2015.00055/full
+            p_nom=1e9,  # kW
+        )
 
-    if solve_opts.get('noisy_costs'):
+    if solve_opts.get("noisy_costs"):
         for t in n.iterate_components(n.one_port_components):
             # if 'capital_cost' in t.df:
             #    t.df['capital_cost'] += 1e1 + 2.*(np.random.random(len(t.df)) - 0.5)
-            if 'marginal_cost' in t.df:
-                t.df['marginal_cost'] += (1e-2 + 2e-3 *
-                                          (np.random.random(len(t.df)) - 0.5))
+            if "marginal_cost" in t.df:
+                t.df["marginal_cost"] += 1e-2 + 2e-3 * (
+                    np.random.random(len(t.df)) - 0.5
+                )
 
-        for t in n.iterate_components(['Line', 'Link']):
-            t.df['capital_cost'] += (1e-1 +
-                                     2e-2*(np.random.random(len(t.df)) - 0.5)) * t.df['length']
+        for t in n.iterate_components(["Line", "Link"]):
+            t.df["capital_cost"] += (
+                1e-1 + 2e-2 * (np.random.random(len(t.df)) - 0.5)
+            ) * t.df["length"]
 
-    if solve_opts.get('nhours'):
-        nhours = solve_opts['nhours']
+    if solve_opts.get("nhours"):
+        nhours = solve_opts["nhours"]
         n.set_snapshots(n.snapshots[:nhours])
-        n.snapshot_weightings[:] = 8760. / nhours
+        n.snapshot_weightings[:] = 8760.0 / nhours
 
     return n
 
 
 def add_CCL_constraints(n, config):
-    agg_p_nom_limits = config['electricity'].get('agg_p_nom_limits')
+    agg_p_nom_limits = config["electricity"].get("agg_p_nom_limits")
 
     try:
-        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits,
-                                       index_col=list(range(2)))
+        agg_p_nom_minmax = pd.read_csv(agg_p_nom_limits, index_col=list(range(2)))
     except IOError:
-        logger.exception("Need to specify the path to a .csv file containing "
-                         "aggregate capacity limits per country in "
-                         "config['electricity']['agg_p_nom_limit'].")
-    logger.info("Adding per carrier generation capacity constraints for "
-                "individual countries")
+        logger.exception(
+            "Need to specify the path to a .csv file containing "
+            "aggregate capacity limits per country in "
+            "config['electricity']['agg_p_nom_limit']."
+        )
+    logger.info(
+        "Adding per carrier generation capacity constraints for " "individual countries"
+    )
 
     gen_country = n.generators.bus.map(n.buses.country)
     # cc means country and carrier
-    p_nom_per_cc = (pd.DataFrame(
-                    {'p_nom': linexpr((1, get_var(n, 'Generator', 'p_nom'))),
-                     'country': gen_country, 'carrier': n.generators.carrier})
-                    .dropna(subset=['p_nom'])
-                    .groupby(['country', 'carrier']).p_nom
-                    .apply(join_exprs))
-    minimum = agg_p_nom_minmax['min'].dropna()
+    p_nom_per_cc = (
+        pd.DataFrame(
+            {
+                "p_nom": linexpr((1, get_var(n, "Generator", "p_nom"))),
+                "country": gen_country,
+                "carrier": n.generators.carrier,
+            }
+        )
+        .dropna(subset=["p_nom"])
+        .groupby(["country", "carrier"])
+        .p_nom.apply(join_exprs)
+    )
+    minimum = agg_p_nom_minmax["min"].dropna()
     if not minimum.empty:
-        minconstraint = define_constraints(n, p_nom_per_cc[minimum.index],
-                                           '>=', minimum, 'agg_p_nom', 'min')
-    maximum = agg_p_nom_minmax['max'].dropna()
+        minconstraint = define_constraints(
+            n, p_nom_per_cc[minimum.index], ">=", minimum, "agg_p_nom", "min"
+        )
+    maximum = agg_p_nom_minmax["max"].dropna()
     if not maximum.empty:
-        maxconstraint = define_constraints(n, p_nom_per_cc[maximum.index],
-                                           '<=', maximum, 'agg_p_nom', 'max')
+        maxconstraint = define_constraints(
+            n, p_nom_per_cc[maximum.index], "<=", maximum, "agg_p_nom", "max"
+        )
 
 
 def add_EQ_constraints(n, o, scaling=1e-1):
     float_regex = "[0-9]*\.?[0-9]+"
     level = float(re.findall(float_regex, o)[0])
-    if o[-1] == 'c':
+    if o[-1] == "c":
         ggrouper = n.generators.bus.map(n.buses.country)
         lgrouper = n.loads.bus.map(n.buses.country)
         sgrouper = n.storage_units.bus.map(n.buses.country)
@@ -176,53 +197,75 @@ def add_EQ_constraints(n, o, scaling=1e-1):
         ggrouper = n.generators.bus
         lgrouper = n.loads.bus
         sgrouper = n.storage_units.bus
-    load = n.snapshot_weightings.generators @ \
-        n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
-    inflow = n.snapshot_weightings.stores @ \
-        n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
-    inflow = inflow.reindex(load.index).fillna(0.)
+    load = (
+        n.snapshot_weightings.generators
+        @ n.loads_t.p_set.groupby(lgrouper, axis=1).sum()
+    )
+    inflow = (
+        n.snapshot_weightings.stores
+        @ n.storage_units_t.inflow.groupby(sgrouper, axis=1).sum()
+    )
+    inflow = inflow.reindex(load.index).fillna(0.0)
     rhs = scaling * (level * load - inflow)
-    lhs_gen = linexpr((n.snapshot_weightings.generators * scaling,
-                       get_var(n, "Generator", "p").T)
-                      ).T.groupby(ggrouper, axis=1).apply(join_exprs)
-    lhs_spill = linexpr((-n.snapshot_weightings.stores * scaling,
-                         get_var(n, "StorageUnit", "spill").T)
-                        ).T.groupby(sgrouper, axis=1).apply(join_exprs)
+    lhs_gen = (
+        linexpr(
+            (n.snapshot_weightings.generators * scaling, get_var(n, "Generator", "p").T)
+        )
+        .T.groupby(ggrouper, axis=1)
+        .apply(join_exprs)
+    )
+    lhs_spill = (
+        linexpr(
+            (
+                -n.snapshot_weightings.stores * scaling,
+                get_var(n, "StorageUnit", "spill").T,
+            )
+        )
+        .T.groupby(sgrouper, axis=1)
+        .apply(join_exprs)
+    )
     lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
     lhs = lhs_gen + lhs_spill
     define_constraints(n, lhs, ">=", rhs, "equity", "min")
 
 
 def add_BAU_constraints(n, config):
-    mincaps = pd.Series(config['electricity']['BAU_mincapacities'])
-    lhs = (linexpr((1, get_var(n, 'Generator', 'p_nom')))
-           .groupby(n.generators.carrier).apply(join_exprs))
-    define_constraints(
-        n, lhs, '>=', mincaps[lhs.index], 'Carrier', 'bau_mincaps')
+    mincaps = pd.Series(config["electricity"]["BAU_mincapacities"])
+    lhs = (
+        linexpr((1, get_var(n, "Generator", "p_nom")))
+        .groupby(n.generators.carrier)
+        .apply(join_exprs)
+    )
+    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier", "bau_mincaps")
 
 
 def add_SAFE_constraints(n, config):
-    peakdemand = (1. + config['electricity']['SAFE_reservemargin']) *\
-        n.loads_t.p_set.sum(axis=1).max()
-    conv_techs = config['plotting']['conv_techs']
-    exist_conv_caps = n.generators.query('~p_nom_extendable & carrier in @conv_techs')\
-                       .p_nom.sum()
-    ext_gens_i = n.generators.query(
-        'carrier in @conv_techs & p_nom_extendable').index
-    lhs = linexpr((1, get_var(n, 'Generator', 'p_nom')[ext_gens_i])).sum()
+    peakdemand = (
+        1.0 + config["electricity"]["SAFE_reservemargin"]
+    ) * n.loads_t.p_set.sum(axis=1).max()
+    conv_techs = config["plotting"]["conv_techs"]
+    exist_conv_caps = n.generators.query(
+        "~p_nom_extendable & carrier in @conv_techs"
+    ).p_nom.sum()
+    ext_gens_i = n.generators.query("carrier in @conv_techs & p_nom_extendable").index
+    lhs = linexpr((1, get_var(n, "Generator", "p_nom")[ext_gens_i])).sum()
     rhs = peakdemand - exist_conv_caps
-    define_constraints(n, lhs, '>=', rhs, 'Safe', 'mintotalcap')
+    define_constraints(n, lhs, ">=", rhs, "Safe", "mintotalcap")
 
 
 def add_battery_constraints(n):
     nodes = n.buses.index[n.buses.carrier == "battery"]
-    if nodes.empty or ('Link', 'p_nom') not in n.variables.index:
+    if nodes.empty or ("Link", "p_nom") not in n.variables.index:
         return
     link_p_nom = get_var(n, "Link", "p_nom")
-    lhs = linexpr((1, link_p_nom[nodes + " charger"]),
-                  (-n.links.loc[nodes + " discharger", "efficiency"].values,
-                   link_p_nom[nodes + " discharger"].values))
-    define_constraints(n, lhs, "=", 0, 'Link', 'charger_ratio')
+    lhs = linexpr(
+        (1, link_p_nom[nodes + " charger"]),
+        (
+            -n.links.loc[nodes + " discharger", "efficiency"].values,
+            link_p_nom[nodes + " discharger"].values,
+        ),
+    )
+    define_constraints(n, lhs, "=", 0, "Link", "charger_ratio")
 
 
 def extra_functionality(n, snapshots):
@@ -233,11 +276,11 @@ def extra_functionality(n, snapshots):
     """
     opts = n.opts
     config = n.config
-    if 'BAU' in opts and n.generators.p_nom_extendable.any():
+    if "BAU" in opts and n.generators.p_nom_extendable.any():
         add_BAU_constraints(n, config)
-    if 'SAFE' in opts and n.generators.p_nom_extendable.any():
+    if "SAFE" in opts and n.generators.p_nom_extendable.any():
         add_SAFE_constraints(n, config)
-    if 'CCL' in opts and n.generators.p_nom_extendable.any():
+    if "CCL" in opts and n.generators.p_nom_extendable.any():
         add_CCL_constraints(n, config)
     for o in opts:
         if "EQ" in o:
@@ -245,53 +288,73 @@ def extra_functionality(n, snapshots):
     add_battery_constraints(n)
 
 
-def solve_network(n, config, opts='', **kwargs):
-    solver_options = config['solving']['solver'].copy()
-    solver_name = solver_options.pop('name')
-    cf_solving = config['solving']['options']
-    track_iterations = cf_solving.get('track_iterations', False)
-    min_iterations = cf_solving.get('min_iterations', 4)
-    max_iterations = cf_solving.get('max_iterations', 6)
+def solve_network(n, config, opts="", **kwargs):
+    solver_options = config["solving"]["solver"].copy()
+    solver_name = solver_options.pop("name")
+    cf_solving = config["solving"]["options"]
+    track_iterations = cf_solving.get("track_iterations", False)
+    min_iterations = cf_solving.get("min_iterations", 4)
+    max_iterations = cf_solving.get("max_iterations", 6)
 
     # add to network for extra_functionality
     n.config = config
     n.opts = opts
 
-    if cf_solving.get('skip_iterations', False):
-        network_lopf(n, solver_name=solver_name, solver_options=solver_options,
-                     extra_functionality=extra_functionality, **kwargs)
+    if cf_solving.get("skip_iterations", False):
+        network_lopf(
+            n,
+            solver_name=solver_name,
+            solver_options=solver_options,
+            extra_functionality=extra_functionality,
+            **kwargs
+        )
     else:
-        ilopf(n, solver_name=solver_name, solver_options=solver_options,
-              track_iterations=track_iterations,
-              min_iterations=min_iterations,
-              max_iterations=max_iterations,
-              extra_functionality=extra_functionality, **kwargs)
+        ilopf(
+            n,
+            solver_name=solver_name,
+            solver_options=solver_options,
+            track_iterations=track_iterations,
+            min_iterations=min_iterations,
+            max_iterations=max_iterations,
+            extra_functionality=extra_functionality,
+            **kwargs
+        )
     return n
 
 
 if __name__ == "__main__":
-    if 'snakemake' not in globals():
+    if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-        snakemake = mock_snakemake('solve_network', network='elec', simpl='',
-                                   clusters='10', ll='v0.3', opts='Co2L-24H')
+        snakemake = mock_snakemake(
+            "solve_network",
+            network="elec",
+            simpl="",
+            clusters="10",
+            ll="v0.3",
+            opts="Co2L-24H",
+        )
     configure_logging(snakemake)
 
-    tmpdir = snakemake.config['solving'].get('tmpdir')
+    tmpdir = snakemake.config["solving"].get("tmpdir")
     if tmpdir is not None:
         Path(tmpdir).mkdir(parents=True, exist_ok=True)
-    opts = snakemake.wildcards.opts.split('-')
-    solve_opts = snakemake.config['solving']['options']
+    opts = snakemake.wildcards.opts.split("-")
+    solve_opts = snakemake.config["solving"]["options"]
 
-    fn = getattr(snakemake.log, 'memory', None)
-    with memory_logger(filename=fn, interval=30.) as mem:
+    fn = getattr(snakemake.log, "memory", None)
+    with memory_logger(filename=fn, interval=30.0) as mem:
         n = pypsa.Network(snakemake.input[0])
         n = prepare_network(n, solve_opts)
-        n = solve_network(n, config=snakemake.config, opts=opts,
-                          solver_dir=tmpdir,
-                          solver_logfile=snakemake.log.solver)
+        n = solve_network(
+            n,
+            config=snakemake.config,
+            opts=opts,
+            solver_dir=tmpdir,
+            solver_logfile=snakemake.log.solver,
+        )
         n.export_to_netcdf(snakemake.output[0])
 
     logger.info("Maximum memory usage: {}".format(mem.mem_usage))


### PR DESCRIPTION
This issue solves these issues:
- automatic data workflow for build_powerplants: the csv input is the output of the data processing
- simplify non-snakemake run of selected scripts: make the scripts runnable easily by just clicking run. To run the function mock_snakemake, the current working directory of python should be the root folder pypsa-africa; when running the scripts in the scripts folder, it is needed to change the current folder to its parent one; that has been better automated
- Fix the procedure used to identify buses in off-shore areas, before the procedure was bugged and the output was improperly evaluated: it run but the output wasn't the expected one. Now the check has been finalized
- the input file "eez_v11.gpkg" has been added as an input for the build_shapes function so that retrieve_databundle is run before build_shapes
- the option "add_line_endings" has been added to the osm_cleaning_data so that when true, the endings of each line are added to the substation list, before the country labeling. This solves the problem shown in #113 . To close #113 it is only left to understand how to manage the interconnection lines between the selected countries and the others; my personal view is to remove them. Next fix to do
-  in osm_build_network the methodology to assign station_ids has been improved to group together substations within a desired tolerance tol and by voltage; in the future we shall also include by type AC/DC. Nodes at different voltages are currently connected by fake lines that basically represent transformers. A development will be to add transformers as PyPSA Europe does
- in osm_build_network  the function set_line_ids has been created to properly allocate and define the bus corresponding to each line ending. The procedure links each line ending to the closest node having the same voltage as the line and modifies the linestring so that the path is complete and the ending of each line terminates to a bus
- osm_build_network outputs and inputs are now taken from snakemake, instead of being hard coded; in alignment to #106 
- Other fixing has been performed to remove problems, e.g. number of circuits = 0, under_construction=True improperly, etc.
- In build_natura_raster, it has been added a featyre so that the user can set as inputs in the snakemake a folder and the code automatically loads any shape file contained in that folder and their nested folders

The notebook "simplify_and_cluster_network" has been improved to derive the images noted in this pull request.

These changes are aligned to #115