### PR TITLE
Remove res from conventional ppls

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -28,6 +28,8 @@ E.g. if a new rule becomes available describe how to use it `snakemake -j1 run_t
 
 * Add codespell linter which corrects word spellings `PR #763 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/763>`__
 
+* Remove RES addition functionality from attach_conventional_generators `PR #769 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/769>`__. Currently wind and solar powerplants stored in powerplants.csv are added to the network by attach_conventional_generators.
+
 PyPSA-Earth 0.2.1
 =================
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -373,7 +373,7 @@ def attach_conventional_generators(
     conventional_config,
     conventional_inputs,
 ):
-    carriers = set(conventional_carriers) | set(extendable_carriers["Generator"])
+    carriers = set(conventional_carriers) | (set(extendable_carriers["Generator"]) - {"solar", "onwind", "offwind-ac", "offwind-dc"})
     _add_missing_carriers_from_costs(n, costs, carriers)
 
     ppl = (

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -370,10 +370,11 @@ def attach_conventional_generators(
     ppl,
     conventional_carriers,
     extendable_carriers,
+    renewable_carriers,
     conventional_config,
     conventional_inputs,
 ):
-    carriers = set(conventional_carriers) | (set(extendable_carriers["Generator"]) - {"solar", "onwind", "offwind-ac", "offwind-dc"})
+    carriers = set(conventional_carriers) | (set(extendable_carriers["Generator"]) - set(renewable_carriers))
     _add_missing_carriers_from_costs(n, costs, carriers)
 
     ppl = (
@@ -805,6 +806,7 @@ if __name__ == "__main__":
         ppl,
         conventional_carriers,
         extendable_carriers,
+        renewable_carriers,
         snakemake.config.get("conventional", {}),
         conventional_inputs,
     )


### PR DESCRIPTION
## Changes proposed in this Pull Request
Here, I propose a slight modification of the code in `add_electricity` rule. Currently, in the `attach_conventional_generators` in `add_electricity.py`, non-conventional powerplants are also considered if `extendable` contains RES powerplants in config file. It does not currently create any problem, since those RES ppls added by `attach_conventional_generators` are rewritten by `attach_wind_and_solar`. In practice, only conventional powerplants need to be added by the `attach_conventional_generators` rule. I have faced this issue, when I tried further clustering (not only by carrier type, but also powerplant type (CHP and PP)).

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
