### PR TITLE
Enable configfile specification for mock_snakemake

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,6 +26,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Include a dedicated cutout for Europe in bundle_config.yaml `PR #1125 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1125>`_
 
+* Enable configfile specification for mock_snakemake `PR #1135 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1135>`_
+
 PyPSA-Earth 0.4.1
 =================
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -574,8 +574,6 @@ def mock_snakemake(
         if isinstance(configfile, str):
             with open(configfile, "r") as file:
                 configfile = yaml.safe_load(file)
-        else:
-            configfile = None
 
         workflow = sm.Workflow(
             snakefile,

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -522,7 +522,7 @@ def get_aggregation_strategies(aggregation_strategies):
     return bus_strategies, generator_strategies
 
 
-def mock_snakemake(rulename, root_dir=None, submodule_dir=None, **wildcards):
+def mock_snakemake(rulename, root_dir=None, submodule_dir=None, configfile=None, **wildcards):
     """
     This function is expected to be executed from the "scripts"-directory of "
     the snakemake project. It returns a snakemake.script.Snakemake object,
@@ -534,6 +534,8 @@ def mock_snakemake(rulename, root_dir=None, submodule_dir=None, **wildcards):
     ----------
     rulename: str
         name of the rule for which the snakemake object should be generated
+    configfile: str
+        path to config file to be used in mock_snakemake
     wildcards:
         keyword arguments fixing the wildcards. Only necessary if wildcards are
         needed.
@@ -566,9 +568,17 @@ def mock_snakemake(rulename, root_dir=None, submodule_dir=None, **wildcards):
             if os.path.exists(p):
                 snakefile = p
                 break
+
+        if isinstance(configfile, str):
+            with open(configfile, 'r') as file:
+                configfile = yaml.safe_load(file)
+        else:
+            configfile = None
+
         workflow = sm.Workflow(
-            snakefile, overwrite_configfiles=[], rerun_triggers=[]
-        )  # overwrite_config=config
+            snakefile, overwrite_configfiles=[], rerun_triggers=[],
+            overwrite_config=configfile
+        )
         workflow.include(snakefile)
         workflow.global_resources = {}
         try:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -522,7 +522,9 @@ def get_aggregation_strategies(aggregation_strategies):
     return bus_strategies, generator_strategies
 
 
-def mock_snakemake(rulename, root_dir=None, submodule_dir=None, configfile=None, **wildcards):
+def mock_snakemake(
+    rulename, root_dir=None, submodule_dir=None, configfile=None, **wildcards
+):
     """
     This function is expected to be executed from the "scripts"-directory of "
     the snakemake project. It returns a snakemake.script.Snakemake object,
@@ -570,14 +572,16 @@ def mock_snakemake(rulename, root_dir=None, submodule_dir=None, configfile=None,
                 break
 
         if isinstance(configfile, str):
-            with open(configfile, 'r') as file:
+            with open(configfile, "r") as file:
                 configfile = yaml.safe_load(file)
         else:
             configfile = None
 
         workflow = sm.Workflow(
-            snakefile, overwrite_configfiles=[], rerun_triggers=[],
-            overwrite_config=configfile
+            snakefile,
+            overwrite_configfiles=[],
+            rerun_triggers=[],
+            overwrite_config=configfile,
         )
         workflow.include(snakefile)
         workflow.global_resources = {}


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. Here I propose to enable specification of configfile while using `mock_snakemake`. It is particularly useful when debugging the scenario with its own run name. Currently, the files are searched in `resources/` or `networks/ ` folders as example. If user had already prepared files in folders under run name, it is not visible. Overwriting config file is enabled in snakemake<8 with overwrite_config parameter, which takes dictionary.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
