### PR TITLE
Remove vresutils

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -37,6 +37,8 @@ E.g. if a new rule becomes available describe how to use it `make test` and in o
 
 * Remove elec-based H2 and battery technologies before addition in `prepare_sector_network.py` script and fix bus names for links that models H2 repuspose network `PR #1198 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1198>`__
 
+* Drop vrestil depenedncy `PR #1220 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1220>`__
+
 **Minor Changes and bug-fixing**
 
 * The default configuration for `electricity:estimate_renewable_capacities:year` was updated from 2020 to 2023. `PR #1106 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1106>`__

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -86,7 +86,6 @@ dependencies:
 - pip:
   - earth-osm>=2.2 # until conda release it out for earth-osm
   - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
-  - git+https://github.com/FRESNA/vresutils@master  # until new pip release > 0.3.1 (strictly)
   - tsam>=1.1.0
   - chaospy  # lastest version only available on pip
   - fake_useragent

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -922,7 +922,7 @@ def get_last_commit_message(path):
 
 
 # PYPSA-EARTH-SEC
-def annuity(n, r=discountrate):
+def annuity(n, r):
     """
     Calculate the annuity factor for an asset with lifetime n years and.
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -24,7 +24,6 @@ import yaml
 from fake_useragent import UserAgent
 from pypsa.components import component_attrs, components
 from shapely.geometry import Point
-from vresutils.costdata import annuity
 
 logger = logging.getLogger(__name__)
 
@@ -923,6 +922,21 @@ def get_last_commit_message(path):
 
 
 # PYPSA-EARTH-SEC
+def annuity(n, r=discountrate):
+    """
+    Calculate the annuity factor for an asset with lifetime n years and.
+
+    discount rate of r, e.g. annuity(20, 0.05) * 20 = 1.6
+    """
+
+    if isinstance(r, pd.Series):
+        return pd.Series(1 / n, index=r.index).where(
+            r == 0, r / (1.0 - 1.0 / (1.0 + r) ** n)
+        )
+    elif r > 0:
+        return r / (1.0 - 1.0 / (1.0 + r) ** n)
+    else:
+        return 1 / n
 
 
 def prepare_costs(

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -74,24 +74,6 @@ if __name__ == "__main__":
     pop_cells = pd.Series(I.dot(nuts3["pop"]))
     gdp_cells = pd.Series(I.dot(nuts3["gdp"]))
 
-    # ------------------------------------------------------------------------
-    # old implementation
-    # ------------------------------------------------------------------------
-    # from functools import partial
-    # from shapely.ops import transform, cascaded_union
-
-    # def area(geom):
-    # return reproject(geom).area
-
-    # def reproject(geom, fr=pyproj.Proj(proj='longlat'), to=pyproj.Proj(proj='aea', lat_1=33., lat_2=72.)):
-    #     reproject_pts = partial(pyproj.transform, fr, to)
-    #     return transform(reproject_pts, geom)
-
-    # in km^2
-    # with mp.Pool(processes=snakemake.threads) as pool:
-    #     cell_areas = pd.Series(pool.map(vshapes.area, grid_cells)) / 1e6
-    # ------------------------------------------------------------------------
-
     area_crs = snakemake.config["crs"]["area_crs"]
     cell_areas = grid_cells.to_crs(area_crs).area / 1e6
 

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     )  # os.path.abspath(snakemake.config["atlite"]["cutout"])
     cutout = atlite.Cutout(cutout_path)
 
-    grid_cells = cutout.grid.geometry.to_list()
+    grid_cells = cutout.grid.geometry
 
     # nuts3 has columns country, gdp, pop, geometry
     nuts3 = gpd.read_file(snakemake.input.nuts3_shapes).set_index("GADM_ID")

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -14,7 +14,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from _helpers import read_csv_nafix
-from vresutils import shapes as vshapes
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
@@ -76,8 +75,8 @@ if __name__ == "__main__":
     gdp_cells = pd.Series(I.dot(nuts3["gdp"]))
 
     # in km^2
-    with mp.Pool(processes=snakemake.threads) as pool:
-        cell_areas = pd.Series(pool.map(vshapes.area, grid_cells)) / 1e6
+    area_crs = snakemake.config["crs"]["area_crs"]
+    cell_areas = grid_cells.to_crs(area_crs).area / 1e6
 
     # pop per km^2
     density_cells_pop = pop_cells / cell_areas

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -74,7 +74,24 @@ if __name__ == "__main__":
     pop_cells = pd.Series(I.dot(nuts3["pop"]))
     gdp_cells = pd.Series(I.dot(nuts3["gdp"]))
 
+    # ------------------------------------------------------------------------
+    # old implementation
+    # ------------------------------------------------------------------------
+    # from functools import partial
+    # from shapely.ops import transform, cascaded_union
+
+    # def area(geom):
+    # return reproject(geom).area
+
+    # def reproject(geom, fr=pyproj.Proj(proj='longlat'), to=pyproj.Proj(proj='aea', lat_1=33., lat_2=72.)):
+    #     reproject_pts = partial(pyproj.transform, fr, to)
+    #     return transform(reproject_pts, geom)
+
     # in km^2
+    # with mp.Pool(processes=snakemake.threads) as pool:
+    #     cell_areas = pd.Series(pool.map(vshapes.area, grid_cells)) / 1e6
+    # ------------------------------------------------------------------------
+
     area_crs = snakemake.config["crs"]["area_crs"]
     cell_areas = grid_cells.to_crs(area_crs).area / 1e6
 


### PR DESCRIPTION
Closes #1211 replacing `vresutil` dependencies.

To give some context, `vresutil` dependencies have been dropped with #803, but re-appeared due to flaws when merging the sector-coupled version.

## Changes proposed in this Pull Request

- [x] reimplemented annuity calculations
- [x] replaced `vresutil` toolset with shapely ones when calculating cell areas when building the population layouts.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
