### PR TITLE
Fix adding H2 export ports for land-locked countries

### DIFF
--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -71,6 +71,9 @@ def select_ports(n):
 
 
 def add_export(n, hydrogen_buses_ports, export_profile):
+    """
+    Adds H2 exports for ports
+    """
     country_shape = gpd.read_file(snakemake.input["shapes_path"])
     # Find most northwestern point in country shape and get x and y coordinates
     country_shape = country_shape.to_crs(

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -43,10 +43,11 @@ def select_ports(n):
     # ports.loc[:, "fraction"] = ports.fraction.round(1)
 
     ports = ports[ports.country.isin(countries)]
-    if len(ports) < 1:
-        logger.error(
+    if ports.empty:
+        logger.warning(
             "No export ports chosen, please add ports to the file data/export_ports.csv"
         )
+        return ports
     gadm_level = snakemake.params.gadm_level
 
     ports["gadm_{}".format(gadm_level)] = ports[["x", "y", "country"]].apply(
@@ -238,8 +239,10 @@ if __name__ == "__main__":
     # get hydrogen export buses/ports
     hydrogen_buses_ports = select_ports(n)
 
-    # add export value and components to network
-    add_export(n, hydrogen_buses_ports, export_profile)
+    # depending on the region, there may be hydrogen ports available (or not)
+    if not hydrogen_buses_ports.empty:
+        # add export value and components to network
+        add_export(n, hydrogen_buses_ports, export_profile)
 
     n.export_to_netcdf(snakemake.output[0])
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1287,6 +1287,9 @@ def add_shipping(n, costs):
     ).squeeze()
     ports = ports[ports.country.isin(countries)]
 
+    if ports.empty:
+        return
+
     gadm_level = options["gadm_level"]
 
     all_navigation = ["total international navigation", "total domestic navigation"]


### PR DESCRIPTION
## Changes proposed in this Pull Request

There may be countries without see ports at all, or with ports which are not suitable for export H2. In this case adding ports for export H2 should be treated differently.


## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
