### PR TITLE
Fix hydrogen export if no export port exists

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -35,6 +35,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix hydrogen export if no export exists to avoid solving issues. `PR #1419 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1419>`__
+
 * Update the applications list for PyPSA-Earth model. `PR #1413 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1413>`__
 
 * Fix problem with a discontinued World Bank data source in prepare_transport_data_input `PR #1410 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1410>`__

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -56,8 +56,10 @@ def select_ports(n):
 
     # Select the hydrogen buses based on nodes with ports. If no ports exist, print info and set all nodes as export
     if ports_sel.empty:
-        hydrogen_buses_ports = n.buses[n.buses.carrier=="H2"]
-        logger.info("No hydrogen export ports are found. Setting all hydrogen buses as export nodes")
+        hydrogen_buses_ports = n.buses[n.buses.carrier == "H2"]
+        logger.info(
+            "No hydrogen export ports are found. Setting all hydrogen buses as export nodes"
+        )
     else:
         hydrogen_buses_ports = n.buses.loc[ports_sel.index + " H2"]
 

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -200,20 +200,20 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "add_export",
             simpl="",
-            clusters="4",
-            ll="c1",
-            opts="Co2L-4H",
+            clusters="10",
+            ll="copt",
+            opts="Co2L-144H",
             planning_horizons="2030",
-            sopts="144H",
+            sopts="3H",
             discountrate="0.071",
-            demand="AB",
-            h2export="120",
+            demand="AP",
+            h2export="3",
             # configfile="test/config.test1.yaml",
         )
 
     overrides = override_component_attrs(snakemake.input.overrides)
     n = pypsa.Network(snakemake.input.network, override_component_attrs=overrides)
-    countries = list(n.buses.country.unique())
+    countries = list(n.buses.country[n.buses.country != ""].unique())
 
     # Create export profile
     export_profile = create_export_profile()

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -54,8 +54,13 @@ def select_ports(n):
     gcol = "gadm_{}".format(gadm_layer_id)
     ports_sel = ports.loc[~ports[gcol].duplicated(keep="first")].set_index(gcol)
 
-    # Select the hydrogen buses based on nodes with ports
-    hydrogen_buses_ports = n.buses.loc[ports_sel.index + " H2"]
+    # Select the hydrogen buses based on nodes with ports. If no ports exist, print info and set all nodes as export
+    if ports_sel.empty:
+        hydrogen_buses_ports = n.buses[n.buses.carrier=="H2"]
+        logger.info("No hydrogen export ports are found. Setting all hydrogen buses as export nodes")
+    else:
+        hydrogen_buses_ports = n.buses.loc[ports_sel.index + " H2"]
+
     hydrogen_buses_ports.index.name = "Bus"
 
     return hydrogen_buses_ports


### PR DESCRIPTION
# Closes #1404 

## Changes proposed in this Pull Request

This PR proposes a fallback option, if no export ports exist (e.g. for landlocked countries). It solves the solver issues I have experienced and documented in #1404.
In addition, the country list is cleaned and stripped from empty entries, to avoid possible errors.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
