### PR TITLE
Align prepare_transport_data_input with Wiki page table

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,7 +13,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
-* Remove duplicates in environment file. `PR #1458 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1473>`__
+* Remove duplicates in environment file. `PR #1473 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1473>`__
 
 * Revised bundle_cutouts_northamerica `PR #1479 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1479>`__
 
@@ -44,6 +44,8 @@ This part of documentation collects descriptive release notes to capture the mai
 * Introduce universal currency conversion to allow use of currencies other than EUR in input data and results `PR #1319 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1319>`__
 
 **Minor Changes and bug-fixing**
+
+* Update code to reflect the Wikipedia source page for `prepare_transport_data_input`. `PR #1486 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1486>`__
 
 * Add efficiency gain and growth rates for other energy consumption and fill missing NaNs with 0. `PR #1468 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1468>`__
 

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -89,7 +89,7 @@ def download_number_of_vehicles():
         vehicles_wiki = pd.DataFrame(columns=["Country", "country", "number cars"])
 
     vehicles_wiki.rename(
-        columns={"Location": "Country", "Road motor vehicles": "number cars"},
+        columns={"Region": "Country", "Road motor vehicles": "number cars"},
         inplace=True,
     )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
@davide-f @ekatef the Wikipedia page has changed yesterday. Luckily it's just a simple change, we just need to update the index name from `Location` to `Region` even though we may need to think about a more "stable" alternative.

cc @yerbol-akhmetov @hazemakhalek @GbotemiB 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
