### PR TITLE
Bugfix GEBCO for build_renewable_profiles for offshore

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -113,6 +113,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Extending powerplant filter option to custom powerplants `PR #1465 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1465>`__
 
+* Fix an issue with the GEBCO file by limiting libgdal-core<3.10 `PR #1519 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1519>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -64,6 +64,7 @@ dependencies:
 - rasterio
 - rioxarray
 - libgdal-hdf5  # to open gebco file
+- libgdal-core<3.10 # to fix a current gebco issue (https://github.com/pypsa-meets-earth/pypsa-earth/issues/1511)
 
 # Plotting
 - geoviews


### PR DESCRIPTION
Minor changes:
- fix an issue with the GEBCO file by limiting libgdal-core<3.10

# Closes #1511.

## Changes proposed in this Pull Request
- limit libgdal-core<3.10 to resolve #1511. A longer discussion on this can be found there.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
