### PR TITLE
Fix the name of the European cutout

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -282,7 +282,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/17QS7qkuCiyj95Pr-ZQRl3qgp5CQE6HTy/view?usp=drive_link
+      gdrive: https://drive.google.com/file/d/1c2-8pChoxv4CDJW01vkPpggBSWHs9Mqi/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -115,7 +115,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix an issue with the GEBCO file by limiting libgdal-core<3.10 `PR #1519 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1519>`__
 
-* Fix a naming issue with European cutout `PR #1521 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1521>`__
+* Fix a naming issue with European cutout `PR #1530 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1530>`__
 
 PyPSA-Earth 0.6.0
 =================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -115,6 +115,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix an issue with the GEBCO file by limiting libgdal-core<3.10 `PR #1519 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1519>`__
 
+* Fix a naming issue with European cutout `PR #1521 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1521>`__
+
 PyPSA-Earth 0.6.0
 =================
 


### PR DESCRIPTION
# Closes #1514 

## Changes proposed in this Pull Request

Minor changes:
- change the link of the European cutout to address a naming issue

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
