### PR TITLE
Add `co2_budget` for emission targets in multiple planning horizon years

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1080,6 +1080,7 @@ rule prepare_sector_network:
         sector_options=config["sector"],
         foresight=config["foresight"],
         water_costs=config["custom_data"]["water_costs"],
+        co2_budget=config["co2_budget"],
     input:
         **branch(sector_enable["land_transport"], TRANSPORT),
         **branch(sector_enable["heat"], HEAT),

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -153,8 +153,8 @@ load_options:
 
 co2_budget:
   enable: false
-  overwrite: true
-  compare: co2limit # choose from: [co2limit, co2base, absolute, {float}]
+  override_co2opt: true
+  co2base_value: co2limit # choose from: [co2limit, co2base, absolute, {float}]
   year:
     2020: 1.0
     2025: 0.85

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -151,6 +151,19 @@ load_options:
   prediction_year: 2030 # Load scenarios available with different prediction year (GDP, population)
   scale: 1 # scales all load time-series, i.e. 2 = doubles load
 
+co2_budget:
+  enable: false
+  overwrite: true
+  compare: co2limit # choose from: [co2limit, co2base, absolute, {float}]
+  year:
+    2020: 1.0
+    2025: 0.85
+    2030: 0.70
+    2035: 0.55
+    2040: 0.40
+    2045: 0.25
+    2050: 0.1
+
 electricity:
   base_voltage: 380.
   voltages: [132., 220., 300., 380., 500., 750.]

--- a/doc/configtables/co2_budget.csv
+++ b/doc/configtables/co2_budget.csv
@@ -1,5 +1,5 @@
 ,Unit,Values,Description
-enable,,"{True, False}",“Switch to select whether to activate this feature.”
-override_co2opts,,"(True, False}",“Switch to select whether to the new co2 limits can override existing previous co2 options.”
-co2base_value,:math:`t_{CO_2-eq}/a`,"""{""co2limit"", ""co2base"", ""absolute"", float}""","“The total system annual carbon dioxide equivalent emissions. The value can be provided as is, refer to existing CO₂ values, or  if 'absolute' is selected, be defined for each planning horizon"
-year,,“Dictionary with planning horizons as keys”,"“CO₂ budget as a fraction of `co2base_value`, if `absolute` is selected, then the total emission is set per planning horizons year”"
+enable,,"{True, False}",Switch to select whether to activate this feature.
+override_co2opts,,"{True, False}",Switch to select whether to the new co2 limits can override existing previous co2 options.
+co2base_value,:math:`t_{CO_2-eq}/a`,"{""co2limit"", ""co2base"", ""absolute"", float}","The total system annual carbon dioxide equivalent emissions. The value can be provided as is, refer to existing CO₂ values, or  if 'absolute' is selected, be defined for each planning horizon"
+year,,Dictionary with planning horizons as keys,"CO₂ budget as a fraction of `co2base_value`. If `absolute` is selected, then the total emission is set per planning horizons year"

--- a/doc/configtables/co2_budget.csv
+++ b/doc/configtables/co2_budget.csv
@@ -1,0 +1,5 @@
+,Unit,Values,Description
+enable,,"{True, False}",“Switch to select whether to activate this feature.”
+override_co2opts,,"(True, False}",“Switch to select whether to the new co2 limits can override existing previous co2 options.”
+co2base_value,:math:`t_{CO_2-eq}/a`,"""{""co2limit"", ""co2base"", ""absolute"", float}""","“The total system annual carbon dioxide equivalent emissions. The value can be provided as is, refer to existing CO₂ values, or  if 'absolute' is selected, be defined for each planning horizon"
+year,,“Dictionary with planning horizons as keys”,"“CO₂ budget as a fraction of `co2base_value`, if `absolute` is selected, then the total emission is set per planning horizons year”"

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -285,7 +285,7 @@ Specifies the options to estimate future electricity demand (load). Different ye
 ``co2_budget``
 =============================
 
-If enabled, this option allows setting different CO₂ targets for each planning horizons. Only supports foresights with planning horizon such as myopic.
+If enabled, this option allows setting different CO₂ targets for each planning horizon year. Only supports foresights with planning horizon such as myopic.
 
 .. literalinclude:: ../config.default.yaml
    :language: yaml

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -280,6 +280,23 @@ Specifies the options to estimate future electricity demand (load). Different ye
 .. warning::
     The snapshots date range (``snapshots\start`` - ``snapshots\end``) must be in the ``weather_year``.
 
+.. _co2_budget_cf:
+
+``co2_budget``
+=============================
+
+If enabled, this option allows setting different CO₂ targets for each planning horizons. Only supports foresights with planning horizon such as myopic.
+
+.. literalinclude:: ../config.default.yaml
+   :language: yaml
+   :start-at: co2_budget:
+   :end-at: 2050:
+
+.. csv-table::
+   :header-rows: 1
+   :widths: 25,10,22,27
+   :file: configtables/co2_budget.csv
+
 .. _electricity_cf:
 
 ``electricity``

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
+* Add the configuration ``co2_budget`` to set CO₂ emission targets in multiple planning horizon years `PR #1553 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1553>`__
+
 * Add pseudo `branch()` to streamline snakemake workflow. Replace this with Snakemake implementation if Snakemake >= 8.3.0. Added an option to configure which sector components to include which when disabled, irrelevant rules are skipped automatically `PR #1538 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1538>`__
 
 **Minor Changes and bug-fixing**

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2949,7 +2949,9 @@ def add_co2_budget(n, co2_budget, investment_year, elec_opts):
         raise ValueError(f"{compare} is not a valid option for co2_budget: compare")
 
     Nyears = n.snapshot_weightings.objective.sum() / 8760.0
-    logger.info(f"Annual emissions for {investment_year} set to {annual_emissions / 1e6:.2f} MtCO₂-eq/year")
+    logger.info(
+        f"Annual emissions for {investment_year} set to {annual_emissions / 1e6:.2f} MtCO₂-eq/year"
+    )
 
     add_co2limit(n, annual_emissions, Nyears)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -28,6 +28,7 @@ from _helpers import (
     three_2_two_digits_country,
     two_2_three_digits_country,
 )
+from prepare_network import add_co2limit
 from prepare_transport_data import prepare_transport_data
 
 logger = logging.getLogger(__name__)
@@ -2917,27 +2918,40 @@ def add_electricity_distribution_grid(n, costs):
         )
 
 
-# def add_co2limit(n, Nyears=1.0, limit=0.0):
-#     print("Adding CO2 budget limit as per unit of 1990 levels of", limit)
+def add_co2_budget(n, co2_budget, investment_year, elec_opts):
+    # Check if CO2Limit already exists
+    if "CO2Limit" in n.global_constraints.index:
+        if co2_budget["overwrite"]:
+            logger.info("CO2Limit already exists, value will be overwritten.")
+            n.global_constraints.drop(index="CO2Limit", inplace=True)
+        else:
+            logger.warning("CO2Limit already exists, value will not be overwritten.")
+            return
 
-#     countries = n.buses.country.dropna().unique()
+    # Get base year emission factor
+    try:
+        year_emission = co2_budget["year"][investment_year]
+    except KeyError:
+        raise KeyError(
+            f"Investment year '{investment_year}' not found in co2_budget: year"
+        )
 
-#     sectors = emission_sectors_from_opts(opts)
+    compare = co2_budget["compare"]
+    if compare == "co2limit":
+        annual_emissions = year_emission * elec_opts["co2limit"]
+    elif compare == "co2base":
+        annual_emissions = year_emission * elec_opts["co2base"]
+    elif compare == "absolute":
+        annual_emissions = year_emission
+    elif isinstance(compare, float):
+        annual_emissions = compare
+    else:
+        raise ValueError(f"{compare} is not a valid option for co2_budget: compare")
 
-#     # convert Mt to tCO2
-#     co2_totals = 1e6 * pd.read_csv(snakemake.input.co2_totals_name, index_col=0)
+    Nyears = n.snapshot_weightings.objective.sum() / 8760.0
+    logger.info(f"Annual emissions for {investment_year} set to {annual_emissions / 1e6:.2f} MtCO₂-eq/year")
 
-#     co2_limit = co2_totals.loc[countries, sectors].sum().sum()
-
-#     co2_limit *= limit * Nyears
-
-#     n.add(
-#         "GlobalConstraint",
-#         "CO2Limit",
-#         carrier_attribute="co2_emissions",
-#         sense="<=",
-#         constant=co2_limit,
-#     )
+    add_co2limit(n, annual_emissions, Nyears)
 
 
 def add_custom_water_cost(n):
@@ -3260,18 +3274,14 @@ if __name__ == "__main__":
             n = average_every_nhours(n, m.group(0))
             break
 
-    # TODO add co2 limit here, if necessary
-    # co2_limit_pu = eval(sopts[0][5:])
-    # co2_limit = co2_limit_pu *
-    # # Add co2 limit
-    # co2_limit = 1e9
-    # n.add(
-    #     "GlobalConstraint",
-    #     "CO2Limit",
-    #     carrier_attribute="co2_emissions",
-    #     sense="<=",
-    #     constant=co2_limit,
-    # )
+    co2_budget = snakemake.params.co2_budget
+    if co2_budget["enable"]:
+        add_co2_budget(
+            n,
+            co2_budget,
+            investment_year,
+            snakemake.params.electricity,
+        )
 
     if options["dac"]:
         add_dac(n, costs)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2943,8 +2943,8 @@ def add_co2_budget(n, co2_budget, investment_year, elec_opts):
         annual_emissions = year_emission * elec_opts["co2base"]
     elif compare == "absolute":
         annual_emissions = year_emission
-    elif isinstance(compare, float):
-        annual_emissions = compare
+    elif isinstance(compare, (int, float)) and compare > 0:
+        annual_emissions = year_emission * compare
     else:
         raise ValueError(f"{compare} is not a valid option for co2_budget: compare")
 

--- a/test/config.myopic.yaml
+++ b/test/config.myopic.yaml
@@ -31,6 +31,13 @@ scenario:
   sopts: ["144h"]
   demand: ["DF"]
 
+co2_budget:
+  enable: true
+  override_co2opt: true
+  co2base_value: co2limit
+  year:
+    2030: 1.0
+
 cluster_options:
   alternative_clustering: false
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When performing **myopic runs**, using the `Co2L` wildcards becomes impractical due to the presence of multiple planning horizon years. To address this, we utilize an existing feature in pypsa-eur: `co2_budget`

We've aimed to make this feature as flexible as possible. Users can choose from several options:

* Base the annual CO₂ budget on the existing `co2base` or `co2limit` values,
* Define a custom value and scale subsequent years relative to it,
* Or assign an **absolute value** for each specific year.

The `overwrite` option serves as a safeguard, informing users when an existing CO₂ limit (set earlier during `prepare_network`) will be overwritten.

```yaml
co2_budget:
  enable: false
  overwrite: true
  compare: co2limit # choose from: [co2limit, co2base, absolute, {float}]
  year:
    2020: 1.0
    2025: 0.85
    2030: 0.70
    2035: 0.55
    2040: 0.40
    2045: 0.25
    2050: 0.1
```

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
