### PR TITLE
Fix offwind depth calculation

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -471,7 +471,7 @@ rule build_renewable_profiles:
     input:
         natura="resources/" + RDIR + "natura.tiff",
         copernicus="data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif",
-        gebco="data/gebco/GEBCO_2021_TID.nc",
+        gebco="data/gebco/GEBCO_2025_sub_ice.nc",
         country_shapes="resources/" + RDIR + "shapes/country_shapes.geojson",
         offshore_shapes="resources/" + RDIR + "shapes/offshore_shapes.geojson",
         hydro_capacities="data/hydro_capacities.csv",

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -36,7 +36,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
       gdrive: https://drive.google.com/file/d/1XnTP6bZoVl5kFjZQlAcmjNXgazOHtFqX/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc
@@ -53,7 +53,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
       gdrive: https://drive.google.com/file/d/1AEmlgBO-6uY_MA4rzmaRJcQ-xE1Z4uHx/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc
@@ -68,7 +68,7 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_MA.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_tutorial_MA.zip?download=1
       gdrive: https://drive.google.com/file/d/1cUei9vH3LzIYfqltaGTaRWCX6J24f1c0/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -177,8 +177,8 @@ databundles:
     category: common
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/13539/files/bundle_data_earth.zip?download=1
-      gdrive: https://drive.google.com/file/d/1zU4VRRBDVIVqoykhK9lnOAr60unVm_x2/view?usp=drive_link
+      zenodo: https://sandbox.zenodo.org/records/313836/files/bundle_data_earth.zip?download=1
+      gdrive: https://drive.google.com/file/d/1P4uMY464lgcp--8fAEYIJbKeNmHdg1Re/view?usp=drive_link
     output:
     - data/eez/eez_v11.gpkg
     - data/gebco/GEBCO_2021_TID.nc

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -95,7 +95,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/3853/files/bundle_cutouts_tutorial_NGBJ.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_cutouts_tutorial_NGBJ.zip?download=1
       gdrive: https://drive.google.com/file/d/1xnomHdXf_c5STrf7jtDiuRlN2zW0FSVC/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
@@ -108,7 +108,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/3853/files/bundle_cutouts_tutorial_BW.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_cutouts_tutorial_BW.zip?download=1
       gdrive: https://drive.google.com/file/d/1DDQAtnIDM0FNC3vCldfHeH__IpTbyIJt/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
@@ -121,7 +121,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/3853/files/bundle_cutouts_tutorial_MA.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/bundle_cutouts_tutorial_MA.zip?download=1
       gdrive: https://drive.google.com/file/d/1j5v2f4E756jmDMa707QvdNJq3xM4bYUk/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
@@ -145,7 +145,7 @@ databundles:
     category: common
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/3853/files/tutorial_data_general.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323571/files/tutorial_data_general.zip?download=1
       gdrive: https://drive.google.com/file/d/1nRLrs_kP0qVl-IHC4BFLjpoKa3HLk2Py/view
     output:
     - data/eez/eez_v11.gpkg
@@ -196,7 +196,7 @@ databundles:
     category: natura
     destination: "data/natura/"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/13539/files/natura_wpda_CC0.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323567/files/natura_wpda_CC0.zip?download=1
       gdrive: https://drive.google.com/file/d/1H-Y7p8UgnbEzJgo9qPc54BpDXS8loX7Y/view?usp=drive_link
     output:
     - data/natura/natura.tiff
@@ -242,7 +242,7 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/13539/files/bundle_cutouts_africa.zip?download=1
+      zenodo: https://sandbox.zenodo.org/records/323567/files/bundle_cutouts_africa.zip?download=1
       gdrive: https://drive.google.com/file/d/1WHv5Dm1GtrDZj-AxJZd3T-NMIBXty3eV/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -39,7 +39,7 @@ databundles:
       zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
       gdrive: https://drive.google.com/file/d/1XnTP6bZoVl5kFjZQlAcmjNXgazOHtFqX/view?usp=drive_link
     output:
-    - data/gebco/GEBCO_2021_TID.nc
+    - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
     - data/gadm/gadm41_NGA/gadm41_NGA.gpkg  # needed in build_shapes
     - data/gadm/gadm41_BEN/gadm41_BEN.gpkg  # needed in build_shapes
@@ -56,7 +56,7 @@ databundles:
       zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
       gdrive: https://drive.google.com/file/d/1AEmlgBO-6uY_MA4rzmaRJcQ-xE1Z4uHx/view?usp=drive_link
     output:
-    - data/gebco/GEBCO_2021_TID.nc
+    - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
     - data/gadm/gadm41_BWA/gadm41_BWA.gpkg  # needed in build_shapes
     - data/gadm/gadm36_BWA/gadm36_BWA.gpkg  # needed in sector-coupled model
@@ -71,7 +71,7 @@ databundles:
       zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_MA.zip?download=1
       gdrive: https://drive.google.com/file/d/1cUei9vH3LzIYfqltaGTaRWCX6J24f1c0/view?usp=drive_link
     output:
-    - data/gebco/GEBCO_2021_TID.nc
+    - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
 
   # load tutorial hydrobasins bundle for Africa only
@@ -181,7 +181,7 @@ databundles:
       gdrive: https://drive.google.com/file/d/1P4uMY464lgcp--8fAEYIJbKeNmHdg1Re/view?usp=drive_link
     output:
     - data/eez/eez_v11.gpkg
-    - data/gebco/GEBCO_2021_TID.nc
+    - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
     - data/ssp2-2.6/2030/era5_2013/Africa.nc
     - data/ssp2-2.6/2030/era5_2013/Asia.nc

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -36,8 +36,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/145504/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
-      gdrive: https://drive.google.com/file/d/12K03Epx3O9o-IQLh9afzCQyT-nMKWM3P/view?usp=drive_link
+      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
+      gdrive: https://drive.google.com/file/d/1XnTP6bZoVl5kFjZQlAcmjNXgazOHtFqX/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -53,8 +53,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/145504/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
-      gdrive: https://drive.google.com/file/d/1YbbYGs1NsSsZYqNX1g1Jo-iJzt5m-81c/view?usp=drive_link
+      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
+      gdrive: https://drive.google.com/file/d/1AEmlgBO-6uY_MA4rzmaRJcQ-xE1Z4uHx/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -68,8 +68,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/3853/files/bundle_tutorial_MA.zip?download=1
-      gdrive: https://drive.google.com/file/d/1VGzE8ZJHAvAQ9X44QNSX4rH3QF7Yi37D/view?usp=drive_link
+      zenodo: https://sandbox.zenodo.org/records/318639/files/bundle_tutorial_MA.zip?download=1
+      gdrive: https://drive.google.com/file/d/1cUei9vH3LzIYfqltaGTaRWCX6J24f1c0/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2021_TID.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -19,6 +19,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Reintroduce sanitize_carriers and sanitize_location to reduce the number of warnings related to components with undefined carriers `PR #1555 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1555>`__
 
+* Fix the offwind depth calculation by providing the proper GEBCO file `PR #1559 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1559>`__
+
 PyPSA-Earth 0.7.0
 =================
 


### PR DESCRIPTION
Fix the offwind depth calculation by providing the GEBCO depth file instead of the GEBCO type identifier.

# Closes #1516

## Changes proposed in this Pull Request

Bugfix:
- provide the right GEBCO files in the bundle_config.yaml
- change the Snakefile to utilize the proper GEBCO file

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
