### PR TITLE
Add possibility to overwrite attributes for sector model

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -143,6 +143,8 @@ PyPSA-Earth 0.7.0
 
 * Avoid adding CO2 pipeline links when option is disabled `PR #1504 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1504>`__
 
+* Add possibility to overwrite cost attributes for sector model `PR #1567 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1567>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1219,6 +1219,15 @@ def prepare_costs(
     )
     modified_costs = modified_costs.fillna(fill_values)
 
+    for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
+        overwrites = config.get(attr)
+        if overwrites is not None:
+            overwrites = pd.Series(overwrites)
+            modified_costs.loc[overwrites.index, attr] = overwrites
+            logger.info(
+                f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
+            )
+
     def annuity_factor(v):
         return annuity(v["lifetime"], v["discount rate"]) + v["FOM"] / 100
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to add functionality to overwrite cost attributes for sector model. Overwriting attributes works fine for power model. The changes are implemented in `load_costs` function in `add_electricity`. However, for the sector model, `prepare_costs` function from `_helpers.py` is used. There is no possibility to overwrite attributes. In other words, even though you specify to overwrite some attribute (eg. VOM for oil) this will not be applied in the sector model. The proposed PR aims to fix it.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
