### PR TITLE
Account for existing batteries in powerplants file and improve logging on installed capacity

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -113,6 +113,7 @@ idx = pd.IndexSlice
 logger = create_logger(__name__)
 logger.propagate = False
 
+
 def normed(s):
     return s / s.sum()
 
@@ -678,9 +679,7 @@ def attach_existing_batteries(n, costs, ppl):
     _add_missing_carriers_from_costs(n, costs, ["battery"])
 
     # Remove duplicates and reset index like in attach_hydro
-    batteries = batteries.reset_index(drop=True).rename(
-        index=lambda s: f"{s} battery"
-    )
+    batteries = batteries.reset_index(drop=True).rename(index=lambda s: f"{s} battery")
 
     max_hours = snakemake.params.electricity["max_hours"]["battery"]
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -670,22 +670,23 @@ def attach_existing_batteries(n, costs, ppl):
     """
     Add existing battery storage units from powerplants.csv to the network.
     """
-    # Filter entries where the carrier is 'battery'
     batteries = ppl.query('carrier == "battery"')
     if batteries.empty:
         logger.info("No existing batteries found in powerplants.csv.")
         return
 
-    # Ensure carrier 'battery' exists in the network
     _add_missing_carriers_from_costs(n, costs, ["battery"])
 
-    # Read max_hours value from config
+    # Remove duplicates and reset index like in attach_hydro
+    batteries = batteries.reset_index(drop=True).rename(
+        index=lambda s: f"{s} battery"
+    )
+
     max_hours = snakemake.params.electricity["max_hours"]["battery"]
 
-    # Add batteries as StorageUnits
     n.madd(
         "StorageUnit",
-        batteries.index.astype(str) + " battery",
+        batteries.index,
         bus=batteries["bus"],
         carrier="battery",
         p_nom=batteries["p_nom"],


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR ensures that battery storage from powerplants.csv is taken into account both in the power-only and sector-coupled networks, and improves logging in `add_electricity` and `prepare_sector_network`, while avoiding duplication of log messages in `add_electricity` and `simplify_network`.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
