### PR TITLE
Fix (plotting): Add missing tech_colors for sector carriers

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1038,6 +1038,15 @@ plotting:
     high-temp electrolysis: "magenta"
     today: "#D2691E"
     Ambient: "k"
+    industry coal emissions: "#654321"
+    agriculture oil: "#1e1e1e"
+    gas emissions: "#666666"
+    industry oil emissions: "#654321"
+    industry electricity: "#222222"
+    rail transport electricity: "grey"
+    solid biomass for industry: "#654321"
+    rail transport oil: "#44DD33"
+    low voltage: "y"
 
 
   nice_names:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -63,6 +63,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Add geojson output to build_osm_network `PR #1611 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1611>`__
 
+* Add missing colors for energy carriers in the sector-coupled model `PR #1625 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1625>`__
+
 PyPSA-Earth 0.7.0
 =================
 


### PR DESCRIPTION
## Description

This PR fixes a `ValueError` that occurs when plotting the post network.

The `n.plot()` function requires a color for every carrier present in the bus MultiIndex.

When these new carriers were not found in the `tech_colors` map, the plot function failed with:

```
ValueError: Colors not defined for all elements in the second MultiIndex
```

## Changes proposed in this Pull Request

The following carriers have been added to the `tech_colors:` list in `config.default.yaml`, with colors assigned based on the existing conventions in the file (e.g., "industry" carriers use dark/muted tones, "emissions" use grays/browns, and transport/grid carriers match their parent categories):

* `industry coal emissions`
* `agriculture oil`
* `gas emissions`
* `industry oil emissions`
* `industry electricity`
* `rail transport electricity`
* `solid biomass for industry`
* `rail transport oil`
* `low voltage`

## Verification

After adding these color definitions and re-running the model with `snakemake -j1 prepare_sector_networks`, the plotting functions execute successfully, and all carriers are now assigned a color.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.