### PR TITLE
Bugfix: Avoid creating duplicate conventional generators by setting `keep_existing_capacities` to `false`

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -747,11 +747,12 @@ sector:
 
   conventional_generation: # generator : carrier
     OCGT: gas
+    CCGT: gas
     oil: oil
     coal: coal
     lignite: lignite
     biomass: biomass
-  keep_existing_capacities: true
+  keep_existing_capacities: false
 
 solving:
   options:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Avoid creating duplicate conventional generators by setting `keep_existing_capacities` to `false`. Convert CCGT as links in `prepare_sector_network` `PR #1630 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1630>`__
+
 * Refine load shedding capacity calculation to use bus-specific maximum loads instead of fixed large values, improving solver performance and numeric stability. Rename load shedding generator carrier to 'load shedding' (now) instead of just 'load' (previously) `PR #1581 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1581>`__
 
 * The configuration setting for ``focus_weights`` has been moved from ``focus_weights:`` to ``cluster_options: focus_weights:``. Backwards compatibility to old config files is maintained `PR #1565 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1565>`__

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -73,6 +73,12 @@ def add_brownfield(n, n_p, year):
         c.df[f"{attr}_nom"] = c.df[f"{attr}_nom_opt"]
         c.df[f"{attr}_nom_extendable"] = False
 
+        # remove assets if name already exist in the new network
+        n_p.mremove(
+            c.name,
+            c.df.index.intersection(getattr(n,c.list_name).index)
+        )
+
         n.import_components_from_dataframe(c.df, c.name)
 
         # copy time-dependent

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -74,10 +74,7 @@ def add_brownfield(n, n_p, year):
         c.df[f"{attr}_nom_extendable"] = False
 
         # remove assets if name already exist in the new network
-        n_p.mremove(
-            c.name,
-            c.df.index.intersection(getattr(n,c.list_name).index)
-        )
+        n_p.mremove(c.name, c.df.index.intersection(getattr(n, c.list_name).index))
 
         n.import_components_from_dataframe(c.df, c.name)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -112,7 +112,7 @@ def add_generation(
     # Not required, because nodes are already defined in "nodes"
     # nodes = pop_layout.index
 
-    fallback = {"OCGT": "gas"}
+    fallback = {"OCGT": "gas", "CCGT": "gas"}
     conventionals = options.get("conventional_generation", fallback)
 
     for generator, carrier in conventionals.items():
@@ -156,6 +156,10 @@ def add_generation(
             efficiency2=costs.at[carrier, "CO2 intensity"],
             lifetime=costs.at[generator, "lifetime"],
         )
+
+        # remove newly added links that have no capacity and are not extendable
+        to_remove = n.links.query("carrier == @carrier & p_nom == 0 & not p_nom_extendable").index
+        n.remove("Link", to_remove)
 
         # set the "co2_emissions" of the carrier to 0, as emissions are accounted by link efficiency separately (efficiency to 'co2 atmosphere' bus)
         n.carriers.loc[carrier, "co2_emissions"] = 0

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -160,8 +160,8 @@ def add_generation(
         # remove newly added links that have no capacity and are not extendable
         to_remove = n.links.query(
             "carrier == @carrier & p_nom == 0 & not p_nom_extendable"
-        ).index.to_list()
-        n.remove("Link", to_remove)
+        ).index
+        n.mremove("Link", to_remove)
 
         # set the "co2_emissions" of the carrier to 0, as emissions are accounted by link efficiency separately (efficiency to 'co2 atmosphere' bus)
         n.carriers.loc[carrier, "co2_emissions"] = 0

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -158,7 +158,9 @@ def add_generation(
         )
 
         # remove newly added links that have no capacity and are not extendable
-        to_remove = n.links.query("carrier == @carrier & p_nom == 0 & not p_nom_extendable").index
+        to_remove = n.links.query(
+            "carrier == @carrier & p_nom == 0 & not p_nom_extendable"
+        ).index
         n.remove("Link", to_remove)
 
         # set the "co2_emissions" of the carrier to 0, as emissions are accounted by link efficiency separately (efficiency to 'co2 atmosphere' bus)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -160,7 +160,7 @@ def add_generation(
         # remove newly added links that have no capacity and are not extendable
         to_remove = n.links.query(
             "carrier == @carrier & p_nom == 0 & not p_nom_extendable"
-        ).index
+        ).index.to_list()
         n.remove("Link", to_remove)
 
         # set the "co2_emissions" of the carrier to 0, as emissions are accounted by link efficiency separately (efficiency to 'co2 atmosphere' bus)


### PR DESCRIPTION
This issue is flagged by @sophiabrl

There is an inaccuracy in modeling myopic scenarios: the capacities of conventional power plants keep increasing even though those carriers are set as non-extendable. After tracing the issue, the underlying cause appears to be the following:

1. In the `rule prepare_sector_network`, the parameter `keep_existing_capacities` is set to `true` by default (unlike in PyPSA-Eur, where it is `false`). This causes conventional capacities calculated in `prepare_sector` to be re-added.
2. In the function `add_generation()` from the same rule, all power plants listed under `sector: conventional_generation` are added. In PyPSA-Eur, this originally only included gas power plants, but was extended here to cover other fossil plants (possibly to reflect interest in expanding fossil capacity or adding CCs). Importantly, these power plants lack a `build_year`.
3. Since `build_year` is missing, the `rule add_brownfield` triggers the function `add_build_year_to_new_assets()`, which assigns these fossil capacities the `build_year` of the current `planning_horizon`. 
4. In the following planning horizon, the same rule detects these assets and re-adds them as existing capacities.
5. Consequently, **the capacity of conventional power plants multiplies with each new planning horizon**.

In most cases, the function `add_power_capacities_installed_before_baseyear()` within the `rule add_existing_baseyear` already adds all conventional capacities along with their respective `build_year`s. Therefore, `add_generation()` is primarily relevant only for extendable carriers.

## Changes proposed in this Pull Request

This pull request introduces the following changes:

* Set `keep_existing_capacities` to `false` by default. This option should only be enabled in **non-myopic** sector models where the user intends to include all conventional capacities regardless of their construction year. (Alternatively, to make it compatible with myopic settings, we would need to assign `build_year`s to all capacities in `prepare_sector_networks` and preceding rules, which would be quite complex.)
* Add `CCGT: gas` to `sector: conventional_generation` to align with PyPSA-Eur.
* Remove newly added links that have zero capacity and are not extendable in  `add_generation()`

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
