### PR TITLE
Allow overwriting existing UNSD zip file during download

### DIFF
--- a/scripts/build_base_energy_totals.py
+++ b/scripts/build_base_energy_totals.py
@@ -402,6 +402,7 @@ if __name__ == "__main__":
                 file_id="1VUV0X-tTQECi2pHdE5EWXjPI2yeCdk6F",
                 dest_path=os.path.join(BASE_DIR, "data/demand/unsd/unsd.zip"),
                 unzip=True,
+                overwrite=True,
             )
 
             # clean up __MACOSX folder if it exists


### PR DESCRIPTION
# Closes #1652 (if applicable).

## Changes proposed in this Pull Request
This is a quick fix to overwrite existing download from gdrive for the UNSD data file

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
