### PR TITLE
Revise ERA5 data availability in cutout guidelines

### DIFF
--- a/doc/customization_copernicus.rst
+++ b/doc/customization_copernicus.rst
@@ -22,7 +22,7 @@ Steps to get access to Copernicus database:
 
 These steps are required to use CDS API which allows an automatic file download while executing `build_cutouts` rule.
 
-The `build_cutout` flag should be set `true` to generate the cutout. After the cutout is ready, it's recommended to set `build_cutout` to `false` to avoid overwriting the existing cutout by accident. The `snapshots` values set when generating the cutout, will determine the temporal parameters of the cutout. Accessible years which can be used to build a cutout depend on ERA5 data availability. `ERA5 page <https://www.ecmwf.int/en/forecasts/datasets/reanalysis-datasets/era5>`_ explains that the data is available from 1950 and updated continuously with about 3 month delay while the data on 1950-1978 should be treated as preliminary as that is a rather recent development.
+The `build_cutout` flag should be set `true` to generate the cutout. After the cutout is ready, it's recommended to set `build_cutout` to `false` to avoid overwriting the existing cutout by accident. The `snapshots` values set when generating the cutout, will determine the temporal parameters of the cutout. Years which can be used to build a cutout depend on ERA5 data availability: as of 2025, data is available `from 1940 until present <https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5>`__. Data is updated with `about 3 month delay <https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation>`__, and uncertainty is higher for earlier years, as fewer weather observations are available for assimilation.
 
 .. note::
 


### PR DESCRIPTION
ERA5 back extension data is no longer preliminary, and now goes all the way back to 1940 per [ECMWF documentation](https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation)

# Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
