### PR TITLE
fix workflow when augmmented_line_connection is false for Tunisia

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -694,7 +694,9 @@ rule cluster_network:
     script:
         "scripts/cluster_network.py"
 
-if(config["augmented_line_connection"].get("add_to_snakefile") == True):
+
+if config["augmented_line_connection"].get("add_to_snakefile") == True:
+
     rule augmented_line_connections:
         params:
             lines=config["lines"],

--- a/Snakefile
+++ b/Snakefile
@@ -694,34 +694,34 @@ rule cluster_network:
     script:
         "scripts/cluster_network.py"
 
-
-rule augmented_line_connections:
-    params:
-        lines=config["lines"],
-        augmented_line_connection=config["augmented_line_connection"],
-        hvdc_as_lines=config["electricity"]["hvdc_as_lines"],
-        electricity=config["electricity"],
-        costs=config["costs"],
-    input:
-        tech_costs=COSTS,
-        network="networks/" + RDIR + "elec_s{simpl}_{clusters}_pre_augmentation.nc",
-        regions_onshore="resources/"
-        + RDIR
-        + "bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson",
-        regions_offshore="resources/"
-        + RDIR
-        + "bus_regions/regions_offshore_elec_s{simpl}_{clusters}.geojson",
-    output:
-        network="networks/" + RDIR + "elec_s{simpl}_{clusters}.nc",
-    log:
-        "logs/" + RDIR + "augmented_line_connections/elec_s{simpl}_{clusters}.log",
-    benchmark:
-        "benchmarks/" + RDIR + "augmented_line_connections/elec_s{simpl}_{clusters}"
-    threads: 1
-    resources:
-        mem_mb=3000,
-    script:
-        "scripts/augmented_line_connections.py"
+if(config["augmented_line_connection"].get("add_to_snakefile") == True):
+    rule augmented_line_connections:
+        params:
+            lines=config["lines"],
+            augmented_line_connection=config["augmented_line_connection"],
+            hvdc_as_lines=config["electricity"]["hvdc_as_lines"],
+            electricity=config["electricity"],
+            costs=config["costs"],
+        input:
+            tech_costs=COSTS,
+            network="networks/" + RDIR + "elec_s{simpl}_{clusters}_pre_augmentation.nc",
+            regions_onshore="resources/"
+            + RDIR
+            + "bus_regions/regions_onshore_elec_s{simpl}_{clusters}.geojson",
+            regions_offshore="resources/"
+            + RDIR
+            + "bus_regions/regions_offshore_elec_s{simpl}_{clusters}.geojson",
+        output:
+            network="networks/" + RDIR + "elec_s{simpl}_{clusters}.nc",
+        log:
+            "logs/" + RDIR + "augmented_line_connections/elec_s{simpl}_{clusters}.log",
+        benchmark:
+            "benchmarks/" + RDIR + "augmented_line_connections/elec_s{simpl}_{clusters}"
+        threads: 1
+        resources:
+            mem_mb=3000,
+        script:
+            "scripts/augmented_line_connections.py"
 
 
 rule add_extra_components:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -68,6 +68,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Add missing colors for energy carriers in the sector-coupled model `PR #1625 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1625>`__
 
+* fix workflow when augmmented_line_connection is false for Tunisia `PR #1677 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1677>`__
+
 PyPSA-Earth 0.7.0
 =================
 


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
For some reason, when modeling with augmented_lined_connection to false, we get the following error message for Tunisia:
AmbiguousRuleException:
Rules augmented_line_connections and cluster_network are ambiguous for the file networks/H2G_A1_TN/elec_s_10.nc.
Consider starting rule output with a unique prefix, constrain your wildcards, or use the ruleorder directive.
Wildcards:
        augmented_line_connections: clusters=10,simpl=
        cluster_network: clusters=10,simpl=
Expected input files:
        augmented_line_connections: resources/H2G_A1_TN/costs_2035.csv networks/H2G_A1_TN/elec_s_10_pre_augmentation.nc resources/H2G_A1_TN/bus_regions/regions_onshore_elec_s_10.geojson resources/H2G_A1_TN/bus_regions/regions_offshore_elec_s_10.geojson
        cluster_network: networks/H2G_A1_TN/elec_s.nc resources/H2G_A1_TN/shapes/country_shapes.geojson resources/H2G_A1_TN/bus_regions/regions_onshore_elec_s.geojson resources/H2G_A1_TN/bus_regions/regions_offshore_elec_s.geojson resources/H2G_A1_TN/shapes/gadm_shapes.geojson resources/H2G_A1_TN/costs_2035.csv resources/H2G_A1_TN/shapes/subregion_shapes.geojson
Expected output files:
        augmented_line_connections: networks/H2G_A1_TN/elec_s_10.nc
        cluster_network: networks/H2G_A1_TN/elec_s_10.nc resources/H2G_A1_TN/bus_regions/regions_onshore_elec_s_10.geojson resources/H2G_A1_TN/bus_regions/regions_offshore_elec_s_10.geojson resources/H2G_A1_TN/bus_regions/busmap_elec_s_10.csv resources/H2G_A1_TN/bus_regions/linemap_elec_s_10.csv

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
