### PR TITLE
Release v0.8.0

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-version: 0.7.0
+version: 0.8.0
 tutorial: false
 
 logging:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-version: 0.7.0
+version: 0.8.0
 tutorial: true
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ author = "PyPSA-Earth developers"
 copyright = f"{datetime.datetime.today().year}, {author}"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.0"
+release = "0.8.0"
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,18 @@ Upcoming release
 This part of documentation collects descriptive release notes to capture the main improvements introduced by developing the model before the next release.
 
 **New Features and Major Changes**
+
+*
+
+**Minor Changes and bug-fixing**
+
+*
+
+
+PyPSA-Earth 0.7.0
+=================
+
+**New Features and Major Changes**
 * Generalize usage of SEG option  `PR #1535 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1535>`__
 
 * Added a hot-fix to handle UNSD data downtime causing CI to fail `PR #1653 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1653>`__
@@ -726,7 +738,7 @@ Release Process
 
 * Make sure thah pinned versions of the environments ``*-pinned.yaml`` in ``envs`` folder are up-to-date.
 
-* Update version number in ``doc/conf.py``, ``default.config.yaml``, ``tutorial.config.yaml`` and ``test/config.*.yaml``.
+* Update version number in ``doc/conf.py``, ``default.config.yaml``, and ``tutorial.config.yaml``.
 
 * Open, review and merge pull request for branch ``release-v0.x.x``.
   Make sure to close issues and PRs or the release milestone with it (e.g. closes #X).

--- a/test/config.custom.yaml
+++ b/test/config.custom.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.7.0
-
 run:
   name: "custom"
   shared_cutouts: true # set to true to share the default cutout(s) across runs

--- a/test/config.landlock.yaml
+++ b/test/config.landlock.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.7.0
-
 countries: ["BW"]
 
 run:

--- a/test/config.monte_carlo.yaml
+++ b/test/config.monte_carlo.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ### CHANGES TO CONFIG.TUTORIAL.YAML ###
-version: 0.7.0
-
 run:
   name: "monte-carlo"
 

--- a/test/config.myopic.yaml
+++ b/test/config.myopic.yaml
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: 0.7.0
 logging_level: INFO
 tutorial: true
 

--- a/test/config.sector.yaml
+++ b/test/config.sector.yaml
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: 0.7.0
 tutorial: true
 
 enable:

--- a/test/config.tutorial.test.yaml
+++ b/test/config.tutorial.test.yaml
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-version: 0.7.0
-
 run:
   name: tutorial
   sector_name: "tutorial"


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

This PR bumps version to 0.8.0.
I'd propose to drop the version tag in the test configs that to me adds unnecessary burden to maintainers, and keep it in config.tutorial and config.default


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
