### PR TITLE
Bump powerplantmatching version to 0.8.0

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -210,7 +210,7 @@ electricity:
     Store: [battery, H2]
     Link: [] # H2 pipeline
 
-  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut)
+  powerplants_filter: (DateOut >= 2022 or DateOut != DateOut) and (DateIn <= 2023 or DateIn != DateIn)
   custom_powerplants: false #  "false" use only powerplantmatching (ppm) data, "merge" combines ppm and custom powerplants, "replace" use only custom powerplants
 
   conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,9 +17,9 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
-*
+* Bump powerplantmatching to 0.8.0 `PR #1699 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1702>`__
 
-PyPSA-Earth 0.7.0
+PyPSA-Earth 0.8.0
 =================
 
 **New Features and Major Changes**

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -14,7 +14,7 @@ dependencies:
 - pypsa>=0.25.1, <=0.30.3
 - atlite>=0.4.1
 - dask
-- powerplantmatching>=0.5.19  # due to this https://github.com/PyPSA/powerplantmatching/pull/202
+- powerplantmatching>=0.8
 - earth-osm>=2.3.post1
 
 # Dependencies of the workflow itself

--- a/envs/linux-64.lock.yaml
+++ b/envs/linux-64.lock.yaml
@@ -384,7 +384,7 @@ dependencies:
 - ply=3.11=pyhd8ed1ab_3
 - polars=1.32.2=default_h9d415db_0
 - polars-default=1.32.2=py39hf521cc8_0
-- powerplantmatching=0.7.1=pyhd8ed1ab_0
+- powerplantmatching=0.8.0=pyhd8ed1ab_0
 - pre-commit=4.3.0=pyha770c72_0
 - progressbar2=4.5.0=pyhd8ed1ab_1
 - proj=9.6.2=h18fbb6c_2

--- a/envs/osx-64.lock.yaml
+++ b/envs/osx-64.lock.yaml
@@ -349,7 +349,7 @@ dependencies:
 - ply=3.11=pyhd8ed1ab_3
 - polars=1.32.2=default_hc55c1fa_0
 - polars-default=1.32.2=py39hbd2d40b_0
-- powerplantmatching=0.7.1=pyhd8ed1ab_0
+- powerplantmatching=0.8.0=pyhd8ed1ab_0
 - pre-commit=4.3.0=pyha770c72_0
 - progressbar2=4.5.0=pyhd8ed1ab_1
 - proj=9.6.2=h8462e38_2

--- a/envs/osx-arm64.lock.yaml
+++ b/envs/osx-arm64.lock.yaml
@@ -349,7 +349,7 @@ dependencies:
 - ply=3.11=pyhd8ed1ab_3
 - polars=1.32.2=default_h931d351_0
 - polars-default=1.32.2=py39h31c57e4_0
-- powerplantmatching=0.7.1=pyhd8ed1ab_0
+- powerplantmatching=0.8.0=pyhd8ed1ab_0
 - pre-commit=4.3.0=pyha770c72_0
 - progressbar2=4.5.0=pyhd8ed1ab_1
 - proj=9.6.2=hdbeaa80_2

--- a/envs/win-64.lock.yaml
+++ b/envs/win-64.lock.yaml
@@ -319,7 +319,7 @@ dependencies:
 - ply=3.11=pyhd8ed1ab_3
 - polars=1.32.2=default_hdbf31e6_0
 - polars-default=1.32.2=py39he906d20_0
-- powerplantmatching=0.7.1=pyhd8ed1ab_0
+- powerplantmatching=0.8.0=pyhd8ed1ab_0
 - pre-commit=4.3.0=pyha770c72_0
 - progressbar2=4.5.0=pyhd8ed1ab_1
 - proj=9.6.2=h7990399_2


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR bumps ppl to 0.8.0 and re-enables the CI


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
