### PR TITLE
Fix missing bus warning for hydrogen due to pypsa version change

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Update steel GEM data to version 2024 and use backup link for GEM pipelines `PR #1708 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1708>`__
 
+* Fix missing bus warning for hydrogen due to pypsa version change `PR #1723 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1723>`__
+
 PyPSA-Earth 0.8.0
 =================
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -456,23 +456,30 @@ def add_hydrogen(n, costs):
             else spatial.nodes + " H2"
         )
 
-        n.madd(
-            "Link",
-            spatial.nodes + " " + h2_tech,
-            bus0=params["bus0"],
-            bus1=bus1,
-            bus2=params.get("bus2", None),
-            bus3=params.get("bus3", None),
-            bus4=params.get("bus4", None),
-            p_nom_extendable=True,
-            carrier=h2_tech,
-            efficiency=params["efficiency"],
-            efficiency2=params.get("efficiency2", 1.0),
-            efficiency3=params.get("efficiency3", 1.0),
-            efficiency4=params.get("efficiency4", 1.0),
-            capital_cost=costs.at[params["cost_name"], "fixed"],
-            lifetime=costs.at[params["cost_name"], "lifetime"],
-        )
+        # Base parameters (always present)
+        link_kwargs = {
+            "bus0": params["bus0"],
+            "bus1": bus1,
+            "p_nom_extendable": True,
+            "carrier": h2_tech,
+            "efficiency": params["efficiency"],
+            "capital_cost": costs.at[params["cost_name"], "fixed"],
+            "lifetime": costs.at[params["cost_name"], "lifetime"],
+        }
+
+        # Optional parameters (only add if present)
+        for key in [
+            "bus2",
+            "bus3",
+            "bus4",
+            "efficiency2",
+            "efficiency3",
+            "efficiency4",
+        ]:
+            if key in params:
+                link_kwargs[key] = params[key]
+
+        n.madd("Link", spatial.nodes + " " + h2_tech, **link_kwargs)
 
     n.madd(
         "Link",


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to fix the warning of missing bus for hydrogen in `prepare_sector_network`. It was due to update to the pypsa version, which previously accepted `None`. But now having `None` in bus3, bus4, bus5 was setting those buses to `None`, previously it was just empty bus. The warning is shown below. It was present even in CI. 

<img width="1287" height="473" alt="image" src="https://github.com/user-attachments/assets/3b154538-e2e0-49e6-97d0-7b21590e9230" />


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
