### PR TITLE
Fix #1745 by sorting unordered list of bundle names

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -33,6 +33,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix warning in of H2 pipeline extension in solve_network `PR #1732 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1732`__
 
+* Fix stochastic bundle names causing rerun of workflow every time `PR #1746 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1746`__
+
 PyPSA-Earth 0.8.0
 =================
 

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -775,7 +775,7 @@ def get_best_bundles(
                     + ", ".join(selection_bundles)
                 )
 
-    return bundles_to_download
+    return sorted(bundles_to_download)
 
 
 def get_best_bundles_in_snakemake(config, include_categories=[], exclude_categories=[]):


### PR DESCRIPTION
# Closes #1745

## Changes proposed in this Pull Request

Sort the list of bundle names returned from the helper function to avoid running the entire workflow (including downloading of bundles) on every rerun.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
