### PR TITLE
fix: #1752 - add hydrobasins to rule input for build_renewable_profile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -492,6 +492,7 @@ HYDRO_PROFILES = {
     "eia_hydro_generation": "data/eia_hydro_annual_generation.csv",
     "irena_stats": "data/IRENA_Statistics_Extract_2025H2.xlsx",
     "powerplants": "resources/" + RDIR + "powerplants.csv",
+    "hydrobasins": "data/hydrobasins/hybas_world.shp",
 }
 
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -45,6 +45,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix stochastic bundle names causing rerun of workflow every time `PR #1746 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1746`__
 
+* Add hydrobasins to rule input for build_renewable_profiles `PR #xxxx <https://github.com/pypsa-meets-earth/pypsa-earth/pull/XXXX`__
+
 PyPSA-Earth 0.8.0
 =================
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -45,7 +45,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix stochastic bundle names causing rerun of workflow every time `PR #1746 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1746`__
 
-* Add hydrobasins to rule input for build_renewable_profiles `PR #xxxx <https://github.com/pypsa-meets-earth/pypsa-earth/pull/XXXX`__
+* Add hydrobasins to rule input for build_renewable_profiles `PR #1753 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1753`__
 
 PyPSA-Earth 0.8.0
 =================


### PR DESCRIPTION
# Closes #1752

## Changes proposed in this Pull Request

Adds missing hydrobasins file to the input list for the build renewable profiles rule.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [x] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [x] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [x] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
