### PR TITLE
Enhance myopic test with additional horizon

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -26,6 +26,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Enhance CI test for myopic optimization (`test/config.myopic.yaml`) by including additional horizon [PR #1776](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1776)
+
 * Add options to use custom shapes for offshore subregions [PR #1769](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1769)
 
 * In `cluster_network`, replace custom voronoi polygon calculation function with Geopandas `gdf.voronoi_polygons` method [PR #1771](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1771)

--- a/test/config.myopic.yaml
+++ b/test/config.myopic.yaml
@@ -25,7 +25,9 @@ disable_subworkflow: true
 scenario:
   simpl: [""]
   clusters: [4]
-  planning_horizons: [2030] # investment years for myopcondaic and perfect; or costs year for overnight
+  planning_horizons:
+  - 2030
+  - 2050
   ll: ["c1"]
   opts: ["Co2L-24H"]
   sopts: ["144h"]

--- a/test/utils/obj_ref.csv
+++ b/test/utils/obj_ref.csv
@@ -15,6 +15,7 @@ monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m5_python.log,2381137807.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m6_python.log,3320198174.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m7_python.log,1367925188.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m8_python.log,390888108.50
-myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2030_0.071_DF_120export_python.log,297275798400.00
+myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2030_0.071_DF_120export_python.log,297283.26
+myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2050_0.071_DF_120export_python.log,677503.78
 sector,elec_s_4_ec_lcopt_CCL-Co2L-24h_144h_2030_0.071_AB_120export_python.log,317046031400.00
 tutorial,elec_s_6_ec_lcopt_Co2L-4H_python.log,2669436608.00

--- a/test/utils/obj_ref.csv
+++ b/test/utils/obj_ref.csv
@@ -15,7 +15,7 @@ monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m5_python.log,2381137807.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m6_python.log,3320198174.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m7_python.log,1367925188.00
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m8_python.log,390888108.50
-myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2030_0.071_DF_120export_python.log,297283.26
-myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2050_0.071_DF_120export_python.log,677503.78
+myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2030_0.071_DF_120export_python.log,297283260000.00
+myopic,elec_s_4_ec_lc1_Co2L-24H_144h_2050_0.071_DF_120export_python.log,677503780000.00
 sector,elec_s_4_ec_lcopt_CCL-Co2L-24h_144h_2030_0.071_AB_120export_python.log,317046031400.00
 tutorial,elec_s_6_ec_lcopt_Co2L-4H_python.log,2669436608.00


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to enhance testing of myopic optimization by adding one more horizon to `test/config.myopic.yaml`. This way, the test CI will be able to assess the effect on `add_brownfield` and `solve_network` rules.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
