### PR TITLE
bugfix in clean osm data

### DIFF
--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -613,10 +613,10 @@ def fill_circuits(df):
                 for (vc, vf) in zip(row["cables"], row["tag_frequency"])
             ]
         )
-
+    
     df.loc[df_match_by_cables.index, "circuits"] = df_match_by_cables.apply(
         _filter_cables, axis=1
-    )
+    ).astype("float64")
 
     # length of cables elements is larger than frequency; the last cable data are merged to match
     df_merge_by_cables = df[to_fill_merge][["tag_frequency", "cables"]].copy()

--- a/scripts/clean_osm_data.py
+++ b/scripts/clean_osm_data.py
@@ -613,7 +613,7 @@ def fill_circuits(df):
                 for (vc, vf) in zip(row["cables"], row["tag_frequency"])
             ]
         )
-    
+
     df.loc[df_match_by_cables.index, "circuits"] = df_match_by_cables.apply(
         _filter_cables, axis=1
     ).astype("float64")


### PR DESCRIPTION
# Closes #

## Changes proposed in this Pull Request
Issue arises as below  in clean_osm_data due to pandas treating a series as str instead of float. 
<img width="1058" height="936" alt="Screenshot 2026-04-03 105710" src="https://github.com/user-attachments/assets/d6639f3b-d1d4-4b75-b839-4839076f029d" />

Fix introduced by type-casting to float64.

Addresses one of issues mentioned in #1715 

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
