### PR TITLE
commented out stray argument in retrieve_databundle that was causing …

### DIFF
--- a/scripts/non_workflow/databundle_cli.py
+++ b/scripts/non_workflow/databundle_cli.py
@@ -263,7 +263,7 @@ if __name__ == "__main__":
         retrieve_databundle(
             bundles,
             config_bundles,
-            hydrobasins_level,
+            # hydrobasins_level,
             rootpath=rootpath,
             disable_progress=disable_progress,
         )


### PR DESCRIPTION
There was a positional argument left in the function `retrieve_databundle()` that was not matching with the arguments from the `retrieve_databundle_light.py` script where the function is originally defined that was causing the script to fail when executed leading error "multiple rootpaths"

# Closes # (if applicable)

## Changes proposed in this Pull Request
I have commented out the argument in case it was put there pending addition of a new feature

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
