### PR TITLE
Avoid crash when no extendable generators are configured

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -28,6 +28,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Avoid crash when no extendable conventional generators are configured [PR #1794](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1794)
+
 * Include country-specific nuclear `p_max_pu` values based on IAEA dataset [PR #1718](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1718)
 
 * Included critical step in the documentation to confirm Terms and Conditions on Copernicus portal to allow for unrestricted use of API. [PR #1785](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1785)

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -28,7 +28,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
-* Avoid crash when no extendable conventional generators are configured [PR #1794](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1794)
+* Avoid crash in add_electricity when no extendable generators are configured [PR #1794](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1794)
 
 * Include country-specific nuclear `p_max_pu` values based on IAEA dataset [PR #1718](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1718)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -661,24 +661,25 @@ def attach_conventional_generators(
         renewable_carriers
     )
 
-    for carrier in extendable_conventional:
-        carrier_buses = ppl[ppl.carrier == carrier]["bus"].unique()
-        n.madd(
-            "Generator",
-            carrier_buses,
-            suffix=" " + carrier,
-            carrier=carrier,
-            bus=carrier_buses,
-            p_nom_extendable=True,
-            efficiency=costs.at[carrier, "efficiency"],
-            marginal_cost=costs.at[carrier, "marginal_cost"],
-            capital_cost=costs.at[carrier, "capital_cost"],
-            lifetime=costs.at[carrier, "lifetime"],
-        )
+    if extendable_conventional:
+        for carrier in extendable_conventional:
+            carrier_buses = ppl[ppl.carrier == carrier]["bus"].unique()
+            n.madd(
+                "Generator",
+                carrier_buses,
+                suffix=" " + carrier,
+                carrier=carrier,
+                bus=carrier_buses,
+                p_nom_extendable=True,
+                efficiency=costs.at[carrier, "efficiency"],
+                marginal_cost=costs.at[carrier, "marginal_cost"],
+                capital_cost=costs.at[carrier, "capital_cost"],
+                lifetime=costs.at[carrier, "lifetime"],
+            )
 
-    logger.info(
-        f"Added extendable {extendable_conventional} generators at {len(carrier_buses)} buses."
-    )
+        logger.info(f"Added extendable {extendable_conventional} generators.")
+    else:
+        logger.info("No extendable conventional generators configured.")
 
     for carrier in conventional_config:
         # Generators with technology affected


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR fixes a crash in `attach_conventional_generators` when no extendable generators are configured.

The issue was encountered while running a **base-year calibration**, where no generator expansion is allowed and therefore:

```yaml
extendable_carriers:
  Generator: []
```

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
