### PR TITLE
Add linker for renewable potential profiles

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -677,9 +677,11 @@ rule add_electricity:
         existing_capacities=config["existing_capacities"],
     input:
         **{
-            f"profile_{tech}": "resources/"
-            + RDIR
-            + f"renewable_profiles/profile_{tech}.nc"
+            f"profile_{tech}": (
+                config["renewable"][tech]["path"]
+                if config["renewable"][tech].get("source", "era5") == "custom"
+                else f"resources/{RDIR}renewable_profiles/profile_{tech}.nc"
+            )
             for tech in config["renewable"]
             if tech in config["electricity"]["renewable_carriers"]
         },

--- a/Snakefile
+++ b/Snakefile
@@ -579,15 +579,12 @@ HYDRO_PROFILES = {
 def inputs_hydro(w):
     return HYDRO_PROFILES if w.technology == "hydro" else {}
 
+
 rule build_glofas_profile:
     input:
-        powerplants="resources/"
-        + RDIR
-        + "powerplants.csv",
-        glofas="cutouts/"
-        + CDIR
+        powerplants="resources/" + RDIR + "powerplants.csv",
+        glofas="cutouts/" + CDIR + "zm-2013-glofas.nc",
         # TODO replace hardcoding
-        + "zm-2013-glofas.nc",
     output:
         profile="resources/" + RDIR + "renewable_profiles/profile_hydro_glofas.nc",
     log:
@@ -599,6 +596,7 @@ rule build_glofas_profile:
         mem_mb=ATLITE_NPROCESSES * 5000,
     script:
         "scripts/build_glofas_profile.py"
+
 
 rule build_renewable_profiles:
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -581,10 +581,10 @@ def inputs_hydro(w):
 
 
 rule build_glofas_profile:
+    # TODO replace hardcoding
     input:
         powerplants="resources/" + RDIR + "powerplants.csv",
         glofas="cutouts/" + CDIR + "zm-2013-glofas.nc",
-        # TODO replace hardcoding
     output:
         profile="resources/" + RDIR + "renewable_profiles/profile_hydro_glofas.nc",
     log:

--- a/Snakefile
+++ b/Snakefile
@@ -579,6 +579,26 @@ HYDRO_PROFILES = {
 def inputs_hydro(w):
     return HYDRO_PROFILES if w.technology == "hydro" else {}
 
+rule build_glofas_profile:
+    input:
+        powerplants="resources/"
+        + RDIR
+        + "powerplants.csv",
+        glofas="cutouts/"
+        + CDIR
+        # TODO replace hardcoding
+        + "zm-2013-glofas.nc",
+    output:
+        profile="resources/" + RDIR + "renewable_profiles/profile_hydro_glofas.nc",
+    log:
+        "logs/" + RDIR + "build_glofas_profile.log",
+    benchmark:
+        "benchmarks/" + RDIR + "build_glofas_profile"
+    threads: ATLITE_NPROCESSES
+    resources:
+        mem_mb=ATLITE_NPROCESSES * 5000,
+    script:
+        "scripts/build_glofas_profile.py"
 
 rule build_renewable_profiles:
     params:

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -277,7 +277,7 @@ atlite:
 
 renewable:
   onwind:
-    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles 
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind
@@ -305,7 +305,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   offwind-ac:
-    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles   
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind
@@ -324,7 +324,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   offwind-dc:
-    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles   
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind
@@ -344,7 +344,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   solar:
-    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles     
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: pv
@@ -366,7 +366,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   hydro:
-    source: custom # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles 
+    source: custom # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     path: ""
     cutout: auto
     hydrobasins_level: 6
@@ -390,7 +390,7 @@ renewable:
     multiplier: 1.1 # multiplier applied after the normalization of the hydro production; default 1.0
     hydro_min_inflow_pu: 1.0 # [hour] A threshold of energy to power ratio to classify hydro powerplants as reservoirs in case type is missed
   csp:
-    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles    
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: csp

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -277,6 +277,7 @@ atlite:
 
 renewable:
   onwind:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles 
     cutout: auto
     resource:
       method: wind
@@ -304,6 +305,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   offwind-ac:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles   
     cutout: auto
     resource:
       method: wind
@@ -322,6 +324,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   offwind-dc:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles   
     cutout: auto
     resource:
       method: wind
@@ -341,6 +344,7 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   solar:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles     
     cutout: auto
     resource:
       method: pv
@@ -362,6 +366,8 @@ renewable:
     clip_p_max_pu: 1.e-2
     extendable: true
   hydro:
+    source: custom # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles 
+    path: ""
     cutout: auto
     hydrobasins_level: 6
     resource:
@@ -384,6 +390,7 @@ renewable:
     multiplier: 1.1 # multiplier applied after the normalization of the hydro production; default 1.0
     hydro_min_inflow_pu: 1.0 # [hour] A threshold of energy to power ratio to classify hydro powerplants as reservoirs in case type is missed
   csp:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles    
     cutout: auto
     resource:
       method: csp

--- a/doc/configtables/snippets/renewable_csp.yaml
+++ b/doc/configtables/snippets/renewable_csp.yaml
@@ -1,4 +1,5 @@
   csp:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: csp

--- a/doc/configtables/snippets/renewable_hydro.yaml
+++ b/doc/configtables/snippets/renewable_hydro.yaml
@@ -1,4 +1,6 @@
   hydro:
+    source: custom # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
+    path: ""
     cutout: auto
     hydrobasins_level: 6
     resource:

--- a/doc/configtables/snippets/renewable_offwind-ac.yaml
+++ b/doc/configtables/snippets/renewable_offwind-ac.yaml
@@ -1,4 +1,5 @@
   offwind-ac:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind

--- a/doc/configtables/snippets/renewable_offwind-dc.yaml
+++ b/doc/configtables/snippets/renewable_offwind-dc.yaml
@@ -1,4 +1,5 @@
   offwind-dc:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind

--- a/doc/configtables/snippets/renewable_onwind.yaml
+++ b/doc/configtables/snippets/renewable_onwind.yaml
@@ -1,4 +1,5 @@
   onwind:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: wind

--- a/doc/configtables/snippets/renewable_solar.yaml
+++ b/doc/configtables/snippets/renewable_solar.yaml
@@ -1,4 +1,5 @@
   solar:
+    source: era5 # use "era5" for a regular cutout workflow and "custom" for custom renewable profiles
     cutout: auto
     resource:
       method: pv

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -86,7 +86,9 @@ if __name__ == "__main__":
 
     inflow_ppl_df = extract_inflow_df(ppl_df=ppls, glofas_xr=glofas_xr)
 
-    ds.to_netcdf(snakemake.output.profile)
+    inflow_xr = transform_to_xr(inflow_ppl_df)
+
+    inflow_xr.to_netcdf(snakemake.output.profile)
 
 
 

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -1,0 +1,87 @@
+import pandas as pd
+import xarray as xr
+
+from add_electricity import load_powerplants
+
+logger = create_logger(__name__)
+
+def extract_inflow_df(
+    ppl_df: pd.Dataframe,
+    glofas_xr: xr.Dataset,
+    # TODO Implement normalisation
+    k: int=1
+    ): -> pd.Dataframe
+    """
+    Extract inflow for locations of hydropowerplants
+    """
+    glofas_copy_xr = glofas_xr.copy(deep=True)
+
+    # TODO Account for the case when there is no hydro generation
+    ppl_hydro_df = ppl_df.query("Fueltype=='Hydro'")
+    
+    ppl_hydro_lat = xr.DataArray(
+        ppl_hydro_df["lat"].to_numpy(),
+        dims="plant",
+        coords={"plant": ppl_hydro_df.index},
+    )
+    
+    ppl_hydro_lon = xr.DataArray(
+        ppl_hydro_df["lon"].to_numpy(),
+        dims="plant",
+        coords={"plant": ppl_hydro_df.index},
+    )
+    # TODO Average by a few cells instead taking only the nearest one
+    ppl_hydro_inflow_xr = glofas_copy_xr["dis24"].sel(
+        latitude=ppl_hydro_lat,
+        longitude=ppl_hydro_lon,
+        method="nearest",
+    )
+
+    ppl_hydro_daily_inflow_df = (
+        ppl_hydro_inflow_xr
+        .to_pandas()
+    )
+    ppl_hydro_daily_inflow_df.index.name = "time"
+    ppl_hydro_daily_inflow_df.columns.name = "plant"
+    
+    ppl_hydro_daily_inflow_df.index = pd.to_datetime(ppl_hydro_daily_inflow_df.index)
+    ppl_hydro_inflow_df = ppl_hydro_daily_inflow_df.resample("1h").interpolate(method="linear")
+
+    return ppl_hydro_inflow_df
+
+def transform_to_xr(inflow_df: pd.Dataframe): -> xr.Dataset
+    """
+    Transform dataframe into xarray dataset with structure 
+    of hydro renewable profile
+    """
+
+    tmp_df = inflow_df
+    
+    hydro_xr = xr.Dataset(
+        data_vars={
+            "inflow": (("plant", "time"), tmp_df.to_numpy().T)
+        },
+        coords={
+            "plant": tmp_df.columns.to_numpy(),
+            "time": tmp_df.index.to_numpy(),
+        },
+    )
+
+    return hydro_xr
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+    snakemake = mock_snakemake("build_glofas_profile")
+    configure_logging(snakemake)
+
+    ppls = load_powerplants(snakemake.input.powerplants)
+    glofas_xr = xr.open_dataset(snakemake.input.glofas)
+
+    inflow_ppl_df = extract_inflow_df(ppl_df=ppls, glofas_xr=glofas_xr)
+
+    ds.to_netcdf(snakemake.output.profile)
+
+
+

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -72,8 +72,11 @@ def transform_to_xr(inflow_df: pd.DataFrame) -> pd.DataFrame:
     return hydro_xr
 
 if __name__ == "__main__":
-    if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+
+    # TODO Avoid excessive import
+    from _helpers import mock_snakemake
+    # if "snakemake" not in globals():
+    #     from _helpers import mock_snakemake
 
     snakemake = mock_snakemake("build_glofas_profile")
     configure_logging(snakemake)

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import xarray as xr
 
+from _helpers import configure_logging, create_logger
 from add_electricity import load_powerplants
 
 logger = create_logger(__name__)

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import pandas as pd
 import xarray as xr
 from _helpers import configure_logging, create_logger

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -1,17 +1,17 @@
 import pandas as pd
 import xarray as xr
-
 from _helpers import configure_logging, create_logger
 from add_electricity import load_powerplants
 
 logger = create_logger(__name__)
 
+
 def extract_inflow_df(
     ppl_df: pd.DataFrame,
     glofas_xr: xr.Dataset,
     # TODO Implement normalisation
-    k: int=1
-    ) -> pd.DataFrame:
+    k: int = 1,
+) -> pd.DataFrame:
     """
     Extract inflow for locations of hydropowerplants
     """
@@ -20,13 +20,13 @@ def extract_inflow_df(
     # TODO Account for the case when there is no hydro generation
     # NB 'technology' contains data on 'Reservoir' and 'Run-Of-River'
     ppl_hydro_df = ppl_df.query("carrier=='hydro'")
-    
+
     ppl_hydro_lat = xr.DataArray(
         ppl_hydro_df["lat"].to_numpy(),
         dims="plant",
         coords={"plant": ppl_hydro_df.index},
     )
-    
+
     ppl_hydro_lon = xr.DataArray(
         ppl_hydro_df["lon"].to_numpy(),
         dims="plant",
@@ -39,30 +39,28 @@ def extract_inflow_df(
         method="nearest",
     )
 
-    ppl_hydro_daily_inflow_df = (
-        ppl_hydro_inflow_xr
-        .to_pandas()
-    )
+    ppl_hydro_daily_inflow_df = ppl_hydro_inflow_xr.to_pandas()
     ppl_hydro_daily_inflow_df.index.name = "time"
     ppl_hydro_daily_inflow_df.columns.name = "plant"
-    
+
     ppl_hydro_daily_inflow_df.index = pd.to_datetime(ppl_hydro_daily_inflow_df.index)
-    ppl_hydro_inflow_df = ppl_hydro_daily_inflow_df.resample("1h").interpolate(method="linear")
+    ppl_hydro_inflow_df = ppl_hydro_daily_inflow_df.resample("1h").interpolate(
+        method="linear"
+    )
 
     return ppl_hydro_inflow_df
 
+
 def transform_to_xr(inflow_df: pd.DataFrame) -> pd.DataFrame:
     """
-    Transform dataframe into xarray dataset with structure 
+    Transform dataframe into xarray dataset with structure
     of hydro renewable profile
     """
 
     tmp_df = inflow_df
-    
+
     hydro_xr = xr.Dataset(
-        data_vars={
-            "inflow": (("plant", "time"), tmp_df.to_numpy().T)
-        },
+        data_vars={"inflow": (("plant", "time"), tmp_df.to_numpy().T)},
         coords={
             "plant": tmp_df.columns.to_numpy(),
             "time": tmp_df.index.to_numpy(),
@@ -71,10 +69,12 @@ def transform_to_xr(inflow_df: pd.DataFrame) -> pd.DataFrame:
 
     return hydro_xr
 
+
 if __name__ == "__main__":
 
     # TODO Avoid excessive import
     from _helpers import mock_snakemake
+
     # if "snakemake" not in globals():
     #     from _helpers import mock_snakemake
 
@@ -89,6 +89,3 @@ if __name__ == "__main__":
     inflow_xr = transform_to_xr(inflow_ppl_df)
 
     inflow_xr.to_netcdf(snakemake.output.profile)
-
-
-

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -18,7 +18,8 @@ def extract_inflow_df(
     glofas_copy_xr = glofas_xr.copy(deep=True)
 
     # TODO Account for the case when there is no hydro generation
-    ppl_hydro_df = ppl_df.query("Fueltype=='Hydro'")
+    # NB 'technology' contains data on 'Reservoir' and 'Run-Of-River'
+    ppl_hydro_df = ppl_df.query("carrier=='hydro'")
     
     ppl_hydro_lat = xr.DataArray(
         ppl_hydro_df["lat"].to_numpy(),

--- a/scripts/build_glofas_profile.py
+++ b/scripts/build_glofas_profile.py
@@ -6,11 +6,11 @@ from add_electricity import load_powerplants
 logger = create_logger(__name__)
 
 def extract_inflow_df(
-    ppl_df: pd.Dataframe,
+    ppl_df: pd.DataFrame,
     glofas_xr: xr.Dataset,
     # TODO Implement normalisation
     k: int=1
-    ): -> pd.Dataframe
+    ) -> pd.DataFrame:
     """
     Extract inflow for locations of hydropowerplants
     """
@@ -49,7 +49,7 @@ def extract_inflow_df(
 
     return ppl_hydro_inflow_df
 
-def transform_to_xr(inflow_df: pd.Dataframe): -> xr.Dataset
+def transform_to_xr(inflow_df: pd.DataFrame) -> pd.DataFrame:
     """
     Transform dataframe into xarray dataset with structure 
     of hydro renewable profile


### PR DESCRIPTION
## Changes proposed in this Pull Request

It could be handy sometimes to have an option of using custom data for renewable potential build from sources different from ERA5 or SARAH to which are currently only providers of climate data. There may be however different sources which are also of interest for particular modelling workflows and it could make sense to add an option to incorporate them.

As an example, the PR demonstrated how to include a custom hydro profile build using GloFAS data with some additional customisation.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
