### PR TITLE
Fix crash in add_chp_constraints for networks without links

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -30,6 +30,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Avoid crash in `add_chp_constraints` when the network has no links, supporting operational models without brownfield/expandable batteries, pumped storage, or DC links [#1750](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1750)
+
 * Avoid crash in add_electricity when no extendable generators are configured [PR #1794](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1794)
 
 * Include country-specific nuclear `p_max_pu` values based on IAEA dataset [PR #1718](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1718)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -826,6 +826,9 @@ def hydrogen_temporal_constraint(n, n_ref, time_period):
 
 
 def add_chp_constraints(n):
+    if n.links.empty:
+        return
+
     electric_bool = (
         n.links.index.str.contains("urban central")
         & n.links.index.str.contains("CHP")


### PR DESCRIPTION
## Summary

Fixes #1750.

`add_chp_constraints` calls `n.links.index.str.contains(...)` unconditionally, which raises `AttributeError: Can only use .str accessor with string values!` when `n.links` is empty (the empty Index has no string dtype to infer from).

This trips operational and dispatch-validation models for regions without DC interconnects, batteries, or pumped storage — `n.links` is legitimately empty in those cases, but the constraint setup runs anyway because `sector.chp` defaults to `true` in `config.default.yaml`.

The function would have produced no constraints on an empty `n.links` regardless: every downstream block is gated by `if not <subset>.empty`, all of which are false on an empty network. The fix is an explicit early return that short-circuits before the `.str` accessor.

## Changes

- `scripts/solve_network.py` — early return in `add_chp_constraints` when `n.links` is empty (3 lines).
- `test/test_solve_network.py` — new pytest regression test asserting the function returns cleanly on an empty-links network.
- `doc/release-notes.md` — note under *Minor Changes and bug-fixing*.

## Verification

- `pytest test/test_solve_network.py` passes locally.
- Confirmed the test catches the original bug: replaying the pre-fix function against an empty-links network reproduces the exact `AttributeError` from the issue.
- `pre-commit run` passes on all changed files (isort, black, codespell, REUSE).

## Prior art

The same one-line guard was applied independently in [open-energy-transition/pypsa-zambia#12](https://github.com/open-energy-transition/pypsa-zambia/pull/12) (merged 2026-03-13) for a Zambia dispatch-validation run. That fix was bundled with downstream-only changes and was not upstreamed; this PR brings it to the upstream repo with a regression test.

## Test plan

- [x] `pytest test/test_solve_network.py` passes
- [x] Pre-fix repro confirms the test would have caught the bug
- [x] `pre-commit run --files` clean on all changes
- [ ] CI on the PR