### PR TITLE
tests: scaffolding + unit tests for solve_network constraint helpers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Unit tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: conda-incubator/setup-miniconda@v4
+      with:
+        miniforge-version: latest
+        activate-environment: pypsa-earth
+        channel-priority: strict
+        conda-remove-defaults: true
+
+    - name: Cache Conda env
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: conda-pytest-${{ runner.os }}-${{ hashFiles('envs/linux-64.lock.yaml') }}
+      id: cache-env
+
+    - name: Update environment
+      if: steps.cache-env.outputs.cache-hit != 'true'
+      run: conda env update -n pypsa-earth -f envs/linux-64.lock.yaml
+
+    - name: Run pytest
+      run: make pytest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-.PHONY: test setup clean
+.PHONY: test setup clean pytest
 
 test:
 	set -e
@@ -30,3 +30,6 @@ clean:
 	snakemake -j1 solve_sector_networks --delete-all-output --configfile test/config.sector.yaml
 	snakemake -j1 solve_sector_networks_myopic --delete-all-output --configfile config.tutorial.yaml test/config.myopic.yaml
 	echo "Clean-up complete."
+
+pytest:
+	pytest test/ -v

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -32,6 +32,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Add unit testing scaffolding (`pytest`) and tests for `add_chp_constraints` and `add_battery_constraints` [#1203](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1203)
+
 * Add config parameter `enable_electricity_connection_cost`, which adds electricity grid connection costs to fixed capital costs for solar and onwind generators in prepare_sector_network [PR #1810](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1810)
 
 * Avoid crash in `add_chp_constraints` when the network has no links, supporting operational models without brownfield/expandable batteries, pumped storage, or DC links [PR #1750](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1750)

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -39,6 +39,7 @@ dependencies:
 - pydoe2
 - shapely!=2.0.4
 - pre-commit
+- pytest
 - matplotlib
 - reverse-geocode
 - country_converter

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared pytest setup. Adds scripts/ to sys.path so test files can import
+modules under scripts/ directly (e.g. `from solve_network import ...`)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))

--- a/test/test_solve_network.py
+++ b/test/test_solve_network.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for the extra-functionality constraints in `solve_network.py`."""
+
+import pandas as pd
+import pypsa
+from solve_network import add_battery_constraints, add_chp_constraints
+
+
+def _base_network():
+    """Return a minimal one-bus, three-snapshot network with a generator and a load."""
+    n = pypsa.Network()
+    n.set_snapshots(pd.date_range("2013-01-01", periods=3, freq="h"))
+    n.add("Bus", "bus0")
+    n.add("Generator", "gen0", bus="bus0", p_nom=100, marginal_cost=10)
+    n.add("Load", "load0", bus="bus0", p_set=50)
+    return n
+
+
+# -- add_chp_constraints ----------------------------------------------------
+
+
+def test_add_chp_constraints_returns_when_no_links():
+    """add_chp_constraints should return without raising on a network with no links."""
+    n = _base_network()
+    assert n.links.empty
+    assert add_chp_constraints(n) is None
+
+
+# -- add_battery_constraints ------------------------------------------------
+
+
+def test_add_battery_constraints_returns_when_no_extendable_links():
+    """add_battery_constraints should return without adding a constraint when no link is extendable."""
+    n = _base_network()
+    n.add(
+        "Link",
+        "battery charger",
+        bus0="bus0",
+        bus1="bus0",
+        p_nom=10,
+        p_nom_extendable=False,
+        efficiency=0.95,
+    )
+    n.add(
+        "Link",
+        "battery discharger",
+        bus0="bus0",
+        bus1="bus0",
+        p_nom=10,
+        p_nom_extendable=False,
+        efficiency=0.9,
+    )
+    n.optimize.create_model()
+    assert add_battery_constraints(n) is None
+    assert "Link-charger_ratio" not in n.model.constraints
+
+
+def test_add_battery_constraints_adds_charger_ratio_constraint():
+    """add_battery_constraints should add the Link-charger_ratio constraint when both sides are extendable."""
+    n = _base_network()
+    n.add(
+        "Link",
+        "battery charger",
+        bus0="bus0",
+        bus1="bus0",
+        p_nom_extendable=True,
+        efficiency=0.95,
+    )
+    n.add(
+        "Link",
+        "battery discharger",
+        bus0="bus0",
+        bus1="bus0",
+        p_nom_extendable=True,
+        efficiency=0.9,
+    )
+    n.optimize.create_model()
+    add_battery_constraints(n)
+
+    assert "Link-charger_ratio" in n.model.constraints
+    constraint = n.model.constraints["Link-charger_ratio"]
+    assert constraint.shape == (1,)


### PR DESCRIPTION
## Summary
Sets up a pytest harness and adds the first batch of unit tests for the
extra-functionality constraint helpers in `scripts/solve_network.py`,
per #1203.

**Scaffolding**
- `test/conftest.py`: prepends `scripts/` to `sys.path` so tests can
  import script modules directly (`scripts/` is not a Python package).
- `Makefile`: new `pytest` target. Separate from the existing `test`
  target, which runs Snakemake.
- `envs/environment.yaml`: adds `pytest`.
- `.github/workflows/pytest.yml`: runs `make pytest` on push/PR to
  `main`, reusing the cached locked conda env.

**Tests** (`test/test_solve_network.py`)
- `test_add_chp_constraints_returns_when_no_links`: regression for the
  `n.links.empty` early-return added in #1801.
- `test_add_battery_constraints_returns_when_no_extendable_links`: no
  constraint added when no battery link is extendable.
- `test_add_battery_constraints_adds_charger_ratio_constraint`:
  verifies the `Link-charger_ratio` constraint is registered with the
  expected shape when both charger and discharger are extendable.

The naming convention `test_<script_name>.py` follows the pattern from
#1209, referenced in the discussion on #1203. Future tests for additional
constraint helpers in `solve_network.py` will be added to this same file.

This is the first slice; remaining functions on the #1203 checklist will
follow once the conftest/test pattern is settled here.

## Test plan
- [x] `make pytest` passes locally (3/3)
- [ ] CI `pytest` job green