### PR TITLE
fix(solve_network): rhs UnboundLocalError and back-pressure leak in add_chp_constraints

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -32,6 +32,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix `UnboundLocalError` and back-pressure RHS leak in `add_chp_constraints` [#1814](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1814)
+
 * Add config parameter `enable_electricity_connection_cost`, which adds electricity grid connection costs to fixed capital costs for solar and onwind generators in prepare_sector_network [PR #1810](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1810)
 
 * Avoid crash in `add_chp_constraints` when the network has no links, supporting operational models without brownfield/expandable batteries, pumped storage, or DC links [PR #1750](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1750)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -882,7 +882,7 @@ def add_chp_constraints(n):
             p.loc[:, heat] * (n.links.efficiency[heat] * n.links.c_b[electric].values)
             - p.loc[:, electric] * n.links.efficiency[electric]
         )
-        n.model.add_constraints(lhs <= rhs, name="chplink-backpressure")
+        n.model.add_constraints(lhs <= 0, name="chplink-backpressure")
 
 
 def add_co2_sequestration_limit(n, sns):


### PR DESCRIPTION
## Summary
Resolves #1814 with a single line change to `add_chp_constraints` in
`scripts/solve_network.py`.

The local variable `rhs` was assigned only inside the fixed-CHP block
(`if not electric_fix.empty:`) but read inside the back-pressure block
(`if not electric.empty:`). The two blocks are gated by different
conditions, so two scenarios were broken:

- **Greenfield CHP** (only extendable CHP, no fixed CHP): function
  raised `UnboundLocalError` because `rhs` was never assigned.
- **Brownfield mix** (fixed + extendable CHP coexist): back-pressure
  RHS silently inherited the fixed plant's `p_nom` value (e.g. 100)
  from the preceding block, where the structurally correct RHS is `0`.

The fix initializes `rhs = 0` at the top of the back-pressure block.
This guarantees `rhs` is always defined when read, and any value left
over from the fix block is overridden by the correct value for the
back-pressure inequality `lhs <= 0`.

A unit-test regression for both scenarios will follow once the test
scaffolding in #1813 lands.

Closes #1814.

## Test plan
- [x] Reproducer from #1814 Scenario A: function returns without error
- [x] Reproducer from #1814 Scenario B: `chplink-backpressure.rhs` is `0` everywhere
- [x] `pre-commit run` passes
- [ ] CI green