### PR TITLE
Fix missing OSM substation tags in build_osm_network

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -32,6 +32,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Avoid crash in `build_osm_network` when merging substations with the same `station_id` if `tag_substation` or `symbol` contains missing OSM metadata [PR #1818](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1818)
+
 * Add CI to update reference objective values [PR #1811](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1811)
 
 * Fix `UnboundLocalError` and back-pressure RHS leak in `add_chp_constraints` [#1814](https://github.com/pypsa-meets-earth/pypsa-earth/issues/1814)

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -55,6 +55,21 @@ TRANSFORMERS_COLUMNS = [
 ]
 
 
+def join_non_null_unique(values, sep="|"):
+    """
+    Join unique non-null values as strings.
+
+    OSM tag columns may contain None/NaN values depending on the region.
+    Directly calling sep.join(values.unique()) can fail when non-string
+    or missing values are present.
+    """
+    return sep.join(
+        str(value)
+        for value in pd.Series(values).dropna().unique()
+        if str(value).strip()
+    )
+
+
 def line_endings_to_bus_conversion(lines):
     # Assign to every line a start and end point
 
@@ -207,9 +222,9 @@ def merge_stations_same_station_id(
                     v_name[0],  # "voltage"
                     bus_row["dc"].all(),  # "dc"
                     # bus_row["dc"].all(),  # "dc"
-                    "|".join(bus_row["symbol"].unique()),  # "symbol"
+                    join_non_null_unique(bus_row["symbol"]),  # "symbol"
                     bus_row["under_construction"].all(),  # "under_construction"
-                    "|".join(bus_row["tag_substation"].unique()),  # "tag_substation"
+                    join_non_null_unique(bus_row["tag_substation"]),  # "tag_substation"
                     bus_row["tag_area"].sum(),  # "tag_area"
                     lon_bus,  # "lon"
                     lat_bus,  # "lat"


### PR DESCRIPTION
Fixes #1817

## Changes proposed in this Pull Request

This PR fixes a robustness issue in `scripts/build_osm_network.py` when merging substations with the same `station_id`.

Previously, `merge_stations_same_station_id()` directly joined unique OSM tag values from `tag_substation`:

```python
"|".join(bus_row["tag_substation"].unique())
````

If the column contained `None` or `NaN` values, the workflow failed with:

```text
TypeError: sequence item 4: expected str instance, NoneType found
```

This can happen with real OSM data where substation metadata is incomplete. I encountered this while generating a high-voltage network for India with:

```yaml
countries: ["IN"]

clean_osm_data_options:
  threshold_voltage: 220000
  tag_substation: false
  add_line_endings: true

build_osm_network:
  group_close_buses: true
  group_tolerance_buses: 10000
  split_overpassing_lines: true
  overpassing_lines_tolerance: 100
```

The PR introduces a small helper function that joins unique non-null values safely by:

1. dropping missing values;
2. converting remaining values to strings;
3. joining the cleaned values with `"|"`.

The helper is used for both `tag_substation` and `symbol`, since both fields may originate from incomplete OSM metadata.

This change only affects metadata aggregation during station merging. It does not change topology construction, voltage handling, line assignment, or station clustering logic.

Tested locally with:

```bash
snakemake -j 8 networks/in_hv_dispatch/elec_s.nc
```

Before this change, the workflow failed in `merge_stations_same_station_id()`.

After this change, `build_osm_network` completes successfully and the workflow generates:

```text
networks/in_hv_dispatch/elec_s.nc
```

## Checklist

* [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
* [x] I tested my contribution locally and it seems to work fine.
* [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
* [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
* [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
* [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
* [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
* [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
* [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
* [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.