### PR TITLE
Add validation of the actual configuration file

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -23,6 +23,7 @@ from _helpers import (
     branch,  # Remove if Snakemake >= 8.3.0
 )
 from build_demand_profiles import get_load_paths_gegis
+from check_config_consistency import write_config_consistency_report
 from retrieve_databundle_light import (
     datafiles_retrivedatabundle,
     get_best_bundles_in_snakemake,
@@ -64,6 +65,14 @@ SDIR = config["summary_dir"].strip("/") + f"/{SECDIR}"
 RESDIR = config["results_dir"].strip("/") + f"/{SECDIR}"
 
 ATLITE_NPROCESSES = config["atlite"].get("nprocesses", 4)
+
+config_issues = write_config_consistency_report(
+    config,
+    "results/" + RDIR + "config_consistency.yaml",
+)
+
+for issue in config_issues:
+    print(f"[config {issue['level']}] {issue['check']}: {issue['message']}")
 
 
 wildcard_constraints:

--- a/Snakefile
+++ b/Snakefile
@@ -23,7 +23,7 @@ from _helpers import (
     branch,  # Remove if Snakemake >= 8.3.0
 )
 from build_demand_profiles import get_load_paths_gegis
-from check_config_consistency import write_config_consistency_report
+from _helpers_config import write_config_consistency_report
 from retrieve_databundle_light import (
     datafiles_retrivedatabundle,
     get_best_bundles_in_snakemake,

--- a/scripts/_helpers_config.py
+++ b/scripts/_helpers_config.py
@@ -6,8 +6,8 @@
 # -*- coding: utf-8 -*-
 
 import os
-import yaml
 
+import yaml
 
 GEGIS_YEARS = [2013, 2015, 2018]
 DEMCAST_YEARS = list(range(1999, 2025))

--- a/scripts/_helpers_config.py
+++ b/scripts/_helpers_config.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# -*- coding: utf-8 -*-
+
+import os
+import yaml
+
+
+GEGIS_YEARS = [2013, 2015, 2018]
+DEMCAST_YEARS = list(range(1999, 2025))
+
+
+def check_load_weather_year(config):
+    issues = []
+
+    source = config.get("load_options", {}).get("source")
+    weather_year = config.get("load_options", {}).get("weather_year")
+
+    if source == "gegis" and weather_year not in GEGIS_YEARS:
+        issues.append(
+            {
+                "level": "error",
+                "check": "load_options.weather_year",
+                "message": (
+                    f"Requested load_options.weather_year={weather_year} is not "
+                    f"available for load_options.source='gegis'. Available weather "
+                    f"years are: {GEGIS_YEARS}."
+                ),
+            }
+        )
+
+    if source == "demcast" and weather_year not in DEMCAST_YEARS:
+        issues.append(
+            {
+                "level": "error",
+                "check": "load_options.weather_year",
+                "message": (
+                    f"Requested load_options.weather_year={weather_year} is not "
+                    f"available for load_options.source='demcast'. Available weather "
+                    f"years are: {DEMCAST_YEARS}."
+                ),
+            }
+        )
+
+    if source not in ["gegis", "demcast"]:
+        issues.append(
+            {
+                "level": "error",
+                "check": "load_options.source",
+                "message": (
+                    f"Unknown load_options.source='{source}'. Expected one of: "
+                    "'gegis', 'demcast'."
+                ),
+            }
+        )
+
+    return issues
+
+
+def check_config_consistency(config):
+    issues = []
+
+    issues.extend(check_load_weather_year(config))
+
+    return issues
+
+
+def write_config_consistency_report(config, output_path):
+    issues = check_config_consistency(config)
+
+    report = {
+        "status": "ok" if not issues else "issues_found",
+        "issues": issues,
+    }
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    with open(output_path, "w") as f:
+        yaml.safe_dump(report, f, sort_keys=False)
+
+    return issues


### PR DESCRIPTION
Relates to #1077

Sketching a way to cross-check consistency of the parameters in an actual configuration file. The aim is to focus on the most impactful points:

- [x] the requested load weather years present in a specified demand dataset (GEGIS or DemandCast)
- [ ] the weather year is the same for the snapshots, renewable potential (cutouts) and demand

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
