### PR TITLE
docs: rename navigation section "Utilities" to "Features"

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -84,7 +84,7 @@ There are multiple ways to get involved and learn more about our work:
 
 - [Optimization](user-guide/optimization.md) - Optimization theory and methods
 
-### Utilities
+### Features
 
 - [Monte Carlo](utilities/monte-carlo.md) - Uncertainty quantification and sensitivity analysis
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ nav:
 - Educational Materials:
   - Optimization: user-guide/optimization.md
 
-- Utilities:
+- Features:
   - Monte Carlo: utilities/monte-carlo.md
 
 - Community & Resources:


### PR DESCRIPTION
## Closes #1763

## Changes proposed in this Pull Request

The top navigation section — and the matching section on the documentation
landing page — that groups the *Monte Carlo* page was labelled **"Utilities"**.
As suggested in #1763, **"Features"** describes this section more accurately.

- `mkdocs.yml`: rename the top-level nav section `Utilities` → `Features`
- `doc/index.md`: rename the matching `### Utilities` section heading → `### Features`

Only the displayed labels change; the page path (`utilities/monte-carlo.md`) is
left unchanged, so no links break. The separate **API Reference → Utilities**
page (helper scripts) is intentionally left untouched, since that name is
correct there.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine. (Documentation label change only; page paths are unchanged.)
