### PR TITLE
fix: raise clear error when emission_extractor returns no data

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -38,6 +38,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Add error when emission_extractor fails [PR #1856](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1856)
+
 * Generalize the hard-coded legacy name `africa_shape` [PR #1848](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1848)
 
 * Reduce execution time of CI tests [PR #1819](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1819)

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -145,6 +145,14 @@ def emission_extractor(filename, emission_year, country_names):
         logger.warning(
             f"The emission value for the following countries has not been found: {missing_ccs}"
         )
+    if emission_by_country.empty:
+        raise ValueError(
+            f"No CO2 emission data could be extracted from '{filename}' for year "
+            f"{emission_year} and countries {list(country_names)} (ISO3: {list(cc_iso3)}). "
+            "The automatic CO2 limit cannot be derived from an empty result. "
+            "Please check the emission data file, the requested base year, or the "
+            "configured countries."
+        )
     return emission_by_country
 
 


### PR DESCRIPTION
## Closes #1289

## Changes proposed in this Pull Request

`emission_extractor()` in `scripts/prepare_network.py` only logged a *warning*
when some country codes were missing from the global emission file, and then
returned the (possibly empty) result. When **no** country matched, the caller
computed `co2limit = emission_extractor(...).sum()`, which evaluates to `0` and
silently sets a wrong "automatic" CO2 limit instead of failing.

This PR raises a `ValueError` with a clear message (file, base year, requested
countries) when the extraction yields an empty result, so the failure surfaces
explicitly rather than producing a misleading limit. The existing warning for
*partially* missing countries is kept unchanged.

## Verification

The repository's tests are Snakemake/config integration tests, and this
function reads the global emission Excel file inside the `prepare_network`
rule, so it isn't covered by a standalone unit test. The change is a guard on
an already-computed value: an empty `emission_by_country` now raises instead of
flowing into `.sum() == 0`. The normal (non-empty) path is unchanged.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine. _(Not run against the full Snakemake setup; see Verification above — the change only adds a guard on an empty result and leaves the normal path untouched.)_
