### PR TITLE
docs: add module + missing function docstrings to _helpers.py

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -118,6 +118,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Update contribution guide [PR #1803](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1803)
 
+* Add module-level and missing function docstrings to `scripts/_helpers.py` [PR #1857](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1857)
+
 
 # PyPSA-Earth 0.8.0
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -494,8 +494,13 @@ def aggregate_costs(
 
 
 def progress_retrieve(
-    url, file, data=None, headers=None, disable_progress=False, roundto=1.0
-):
+    url: str,
+    file: str,
+    data=None,
+    headers: dict | None = None,
+    disable_progress: bool = False,
+    roundto: float = 1.0,
+) -> None:
     """
     Function to download data from a url with a progress bar progress in
     retrieving data.
@@ -537,7 +542,13 @@ def progress_retrieve(
         urllib.request.urlretrieve(url, file, reporthook=dlProgress, data=data)
 
 
-def content_retrieve(url, data=None, headers=None, max_retries=3, backoff_factor=0.3):
+def content_retrieve(
+    url: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+    max_retries: int = 3,
+    backoff_factor: float = 0.3,
+) -> io.BytesIO:
     """
     Retrieve the content of a url with improved robustness.
 
@@ -596,7 +607,7 @@ def content_retrieve(url, data=None, headers=None, max_retries=3, backoff_factor
     raise Exception("Max retries exceeded")
 
 
-def get_aggregation_strategies(aggregation_strategies):
+def get_aggregation_strategies(aggregation_strategies: dict) -> tuple[dict, dict]:
     """
     Default aggregation strategies that cannot be defined in .yaml format must
     be specified within the function, otherwise (when defaults are passed in
@@ -622,7 +633,11 @@ def get_aggregation_strategies(aggregation_strategies):
 
 
 def mock_snakemake(
-    rulename, root_dir=None, submodule_dir=None, configfile=None, **wildcards
+    rulename: str,
+    root_dir: str | Path | None = None,
+    submodule_dir: str | None = None,
+    configfile: str | None = None,
+    **wildcards,
 ):
     """
     This function is expected to be executed from the "scripts"-directory of "

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -181,7 +181,7 @@ def create_logger(logger_name: str, level: int = logging.INFO) -> logging.Logger
     return logger
 
 
-def read_osm_config(*args: str) -> dict | str | tuple:
+def read_osm_config(*args: str):
     """
     Read values from the regions config file based on provided key arguments.
 
@@ -744,7 +744,7 @@ def mock_snakemake(
     return snakemake
 
 
-def two_2_three_digits_country(two_code_country):
+def two_2_three_digits_country(two_code_country: str) -> str:
     """
     Convert 2-digit to 3-digit country code:
 
@@ -765,7 +765,7 @@ def two_2_three_digits_country(two_code_country):
     return three_code_country
 
 
-def three_2_two_digits_country(three_code_country):
+def three_2_two_digits_country(three_code_country: str) -> str:
     """
     Convert 3-digit to 2-digit country code:
 
@@ -786,7 +786,9 @@ def three_2_two_digits_country(three_code_country):
     return two_code_country
 
 
-def two_digits_2_name_country(two_code_country, nocomma=False, remove_start_words=[]):
+def two_digits_2_name_country(
+    two_code_country: str, nocomma: bool = False, remove_start_words: list = []
+) -> str:
     """
     Convert 2-digit country code to full name country:
 
@@ -832,7 +834,7 @@ def two_digits_2_name_country(two_code_country, nocomma=False, remove_start_word
     return full_name
 
 
-def country_name_2_two_digits(country_name):
+def country_name_2_two_digits(country_name: str) -> str:
     """
     Convert full country name to 2-digit country code.
 
@@ -1004,7 +1006,7 @@ def read_geojson(fn, cols=[], dtype=None, crs="EPSG:4326"):
         return df
 
 
-def create_country_list(input, iso_coding=True):
+def create_country_list(input: list[str], iso_coding: bool = True) -> list[str]:
     """
     Create a country list for defined regions..
 
@@ -1299,7 +1301,7 @@ def cycling_shift(df, steps=1):
     return df
 
 
-def get_country(target, **keys):
+def get_country(target: str, **keys: str) -> str | float:
     """
     Function to convert country codes using pycountry.
 
@@ -1337,7 +1339,9 @@ def get_country(target, **keys):
         return np.nan
 
 
-def download_GADM(country_code, update=False, out_logging=False):
+def download_GADM(
+    country_code: str, update: bool = False, out_logging: bool = False
+) -> tuple[str, str]:
     """
     Download gpkg file from GADM for a given country code.
 
@@ -1392,7 +1396,9 @@ def download_GADM(country_code, update=False, out_logging=False):
     return GADM_inputfile_gpkg, GADM_filename
 
 
-def _get_shape_col_gdf(path_to_gadm, co, gadm_layer_id, gadm_clustering):
+def _get_shape_col_gdf(
+    path_to_gadm: str | None, co: str, gadm_layer_id: int, gadm_clustering: bool
+) -> tuple[gpd.GeoDataFrame, str]:
     """
     Parameters
     ----------
@@ -1435,14 +1441,14 @@ def _get_shape_col_gdf(path_to_gadm, co, gadm_layer_id, gadm_clustering):
 
 
 def locate_bus(
-    df,
-    countries,
-    gadm_level,
-    path_to_gadm=None,
-    gadm_clustering=False,
-    dropnull=True,
-    col_out=None,
-):
+    df: pd.DataFrame,
+    countries: list,
+    gadm_level: int,
+    path_to_gadm: str | None = None,
+    gadm_clustering: bool = False,
+    dropnull: bool = True,
+    col_out: str | None = None,
+) -> pd.DataFrame:
     """
     Function to locate the points of the dataframe df into the GADM shapefile.
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1151,8 +1151,12 @@ def update_config_dictionary(
 
 
 def create_network_topology(
-    n, prefix, like="ac", connector=" <-> ", bidirectional=True
-):
+    n: pypsa.Network,
+    prefix: str,
+    like: str = "ac",
+    connector: str = " <-> ",
+    bidirectional: bool = True,
+) -> pd.DataFrame:
     """
     Create a network topology like the power transmission network.
 
@@ -1205,7 +1209,7 @@ def create_network_topology(
     return topo
 
 
-def create_dummy_data(n, sector, carriers):
+def create_dummy_data(n: pypsa.Network, sector: str, carriers: list) -> pd.DataFrame:
     """
     Create randomised dummy demand data for a sector (placeholder/testing use).
 
@@ -1293,7 +1297,7 @@ def create_dummy_data(n, sector, carriers):
 #     return energy_totals
 
 
-def cycling_shift(df, steps=1):
+def cycling_shift(df: pd.DataFrame | pd.Series, steps: int = 1) -> pd.DataFrame | pd.Series:
     """
     Cyclic shift on index of pd.Series|pd.DataFrame by number of steps.
     """

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -5,6 +5,33 @@
 
 # -*- coding: utf-8 -*-
 
+"""
+Shared utility functions used across the PyPSA-Earth workflow.
+
+This module collects small, reusable helpers that are imported as ``_helpers``
+by many of the ``scripts/*.py`` rule scripts rather than belonging to a single
+rule. It is not meant to be run as a standalone Snakemake rule. The helpers are
+grouped roughly as follows:
+
+- **Configuration and logging**: ``check_config_version``,
+  ``update_cutout_config``, ``copy_default_files``, ``create_logger``,
+  ``configure_logging``, ``handle_exception``, ``read_osm_config``,
+  ``update_config_dictionary``.
+- **Network aggregation**: ``update_p_nom_max``, ``aggregate_p_nom``,
+  ``aggregate_p``, ``aggregate_e_nom``, ``aggregate_p_curtailed``,
+  ``aggregate_costs``, ``create_network_topology``.
+- **Country handling**: ``two_2_three_digits_country``,
+  ``three_2_two_digits_country``, ``country_name_2_two_digits``,
+  ``two_digits_2_name_country``, ``create_country_list``, ``get_country``,
+  ``add_transform_iso3``.
+- **I/O helpers**: ``read_csv_nafix``, ``to_csv_nafix``, ``save_to_geojson``,
+  ``read_geojson``, ``download_GADM``, ``content_retrieve``,
+  ``progress_retrieve``.
+- **Snakemake helpers**: ``mock_snakemake``, ``get_aggregation_strategies``.
+- **Sector-coupling helpers**: ``get_conv_factors``, ``aggregate_fuels``,
+  ``rename_techs``, ``safe_divide``.
+"""
+
 import calendar
 import io
 import logging
@@ -122,6 +149,13 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 def copy_default_files():
+    """
+    Create a minimal ``config.yaml`` next to ``config.default.yaml`` if missing.
+
+    If no ``config.yaml`` exists in the repository root, write a small
+    placeholder file instructing the user to add only the entries that differ
+    from ``config.default.yaml``.
+    """
     fn = Path(os.path.join(BASE_DIR, "config.yaml"))
     if not fn.exists():
         fn.write_text(
@@ -231,12 +265,41 @@ def configure_logging(snakemake, skip_handlers=False):
 
 
 def pdbcast(v, h):
+    """
+    Broadcast two pandas Series into a DataFrame via an outer product.
+
+    Parameters
+    ----------
+    v : pandas.Series
+        Series providing the row index and the values broadcast down the rows.
+    h : pandas.Series
+        Series providing the column index and the values broadcast across columns.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by ``v.index`` with columns ``h.index`` where entry
+        ``(i, j)`` equals ``v[i] * h[j]``.
+    """
     return pd.DataFrame(
         v.values.reshape((-1, 1)) * h.values, index=v.index, columns=h.index
     )
 
 
 def update_p_nom_max(n):
+    """
+    Ensure ``p_nom_max`` is at least ``p_nom_min`` for all generators.
+
+    When existing assets (e.g. from the OPSD project) are included, the already
+    installed capacity may exceed the configured expansion limit. This sets
+    ``n.generators.p_nom_max`` to the row-wise maximum of ``p_nom_min`` and
+    ``p_nom_max`` so the optimisation stays feasible.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network whose ``generators.p_nom_max`` column is updated in place.
+    """
     # if extendable carriers (solar/onwind/...) have capacity >= 0,
     # e.g. existing assets from the OPSD project are included to the network,
     # the installed capacity might exceed the expansion limit.
@@ -246,6 +309,20 @@ def update_p_nom_max(n):
 
 
 def aggregate_p_nom(n):
+    """
+    Aggregate optimal nominal power capacity per carrier.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Solved network.
+
+    Returns
+    -------
+    pandas.Series
+        Optimal nominal power (``p_nom_opt``) of generators, storage units and
+        links plus the mean load, grouped by carrier.
+    """
     return pd.concat(
         [
             n.generators.groupby("carrier").p_nom_opt.sum(),
@@ -257,6 +334,20 @@ def aggregate_p_nom(n):
 
 
 def aggregate_p(n):
+    """
+    Aggregate dispatched power per carrier.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Solved network.
+
+    Returns
+    -------
+    pandas.Series
+        Total dispatched power of generators, storage units and stores, and the
+        (negative) load, grouped by carrier.
+    """
     return pd.concat(
         [
             n.generators_t.p.sum().groupby(n.generators.carrier).sum(),
@@ -268,6 +359,20 @@ def aggregate_p(n):
 
 
 def aggregate_e_nom(n):
+    """
+    Aggregate optimal nominal energy storage capacity per carrier.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Solved network.
+
+    Returns
+    -------
+    pandas.Series
+        Optimal energy capacity of storage units (``p_nom_opt * max_hours``) and
+        stores (``e_nom_opt``), grouped by carrier.
+    """
     return pd.concat(
         [
             (n.storage_units["p_nom_opt"] * n.storage_units["max_hours"])
@@ -279,6 +384,20 @@ def aggregate_e_nom(n):
 
 
 def aggregate_p_curtailed(n):
+    """
+    Aggregate curtailed power per carrier.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Solved network.
+
+    Returns
+    -------
+    pandas.Series
+        Curtailed power of generators (available minus dispatched) and storage
+        units (inflow minus dispatch), grouped by carrier.
+    """
     return pd.concat(
         [
             (
@@ -299,6 +418,29 @@ def aggregate_p_curtailed(n):
 
 
 def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
+    """
+    Aggregate capital and marginal system costs per component and carrier.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Solved network.
+    flatten : bool, default False
+        If True, collapse the result into a single Series combining capital and
+        marginal costs (marginal costs of conventional technologies are renamed
+        with a `` marginal`` suffix). Requires ``opts``.
+    opts : dict, optional
+        Options dictionary; must contain ``"conv_techs"`` when ``flatten`` is True.
+    existing_only : bool, default False
+        If True, use installed capacities (``p_nom``/``e_nom``) instead of the
+        optimised ones (``p_nom_opt``/``e_nom_opt``).
+
+    Returns
+    -------
+    pandas.Series
+        Costs indexed by (component, cost type, carrier), or a flattened Series
+        when ``flatten`` is True.
+    """
     components = dict(
         Link=("p_nom", "p0"),
         Generator=("p_nom", "p"),
@@ -703,6 +845,29 @@ def read_csv_nafix(file, **kwargs):
 
 
 def to_csv_nafix(df, path, **kwargs):
+    """
+    Write a DataFrame to CSV using the project's standard NA representation.
+
+    Counterpart to :func:`read_csv_nafix`. Empty DataFrames are written as an
+    empty file so downstream Snakemake rules still find their expected output.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to write.
+    path : str or pathlib.Path
+        Destination file path.
+    **kwargs
+        Additional keyword arguments forwarded to
+        :meth:`pandas.DataFrame.to_csv`; any ``na_rep`` is overridden with the
+        project default.
+
+    Returns
+    -------
+    str or None
+        The CSV as a string if ``path`` is None and the frame is non-empty,
+        otherwise None.
+    """
     if "na_rep" in kwargs:
         del kwargs["na_rep"]
     # if len(df) > 0:
@@ -754,6 +919,19 @@ def add_transform_iso3(
 
 
 def save_to_geojson(df, fn):
+    """
+    Save a (Geo)DataFrame to a GeoJSON file, overwriting any existing file.
+
+    Empty frames are written as an empty file to avoid breaking Snakemake rules
+    that expect the output to exist.
+
+    Parameters
+    ----------
+    df : geopandas.GeoDataFrame
+        (Geo)DataFrame to save.
+    fn : str or pathlib.Path
+        Destination file path.
+    """
     if os.path.exists(fn):
         os.unlink(fn)  # remove file if it exists
 
@@ -916,6 +1094,23 @@ def update_config_dictionary(
     parameter_key_to_fill="lines",
     dict_to_use={"geometry": "first", "bounds": "first"},
 ):
+    """
+    Ensure a configuration sub-dictionary exists and update it with defaults.
+
+    Parameters
+    ----------
+    config_dict : dict
+        Configuration dictionary to update in place.
+    parameter_key_to_fill : str, default "lines"
+        Key under which the sub-dictionary is created if absent.
+    dict_to_use : dict, default {"geometry": "first", "bounds": "first"}
+        Key/value pairs merged into ``config_dict[parameter_key_to_fill]``.
+
+    Returns
+    -------
+    dict
+        The updated configuration dictionary.
+    """
     config_dict.setdefault(parameter_key_to_fill, {})
     config_dict[parameter_key_to_fill].update(dict_to_use)
     return config_dict
@@ -977,6 +1172,29 @@ def create_network_topology(
 
 
 def create_dummy_data(n, sector, carriers):
+    """
+    Create randomised dummy demand data for a sector (placeholder/testing use).
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network providing the AC bus index used as the data index.
+    sector : str
+        Sector to create dummy data for. Only ``"industry"`` is supported.
+    carriers : list
+        Unused; kept for interface compatibility.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Random integer demand values indexed by AC bus with one column per
+        industry carrier.
+
+    Raises
+    ------
+    Exception
+        If ``sector`` is not ``"industry"``.
+    """
     ind = n.buses_t.p.index
     ind = n.buses.index[n.buses.carrier == "AC"]
 
@@ -1241,6 +1459,22 @@ def locate_bus(
 
 
 def get_conv_factors(sector):
+    """
+    Return conversion factors from mass/volume units to TWh per fuel.
+
+    The factors convert ktons (or m³) to TWh, based on the UN energy balance
+    methodology (https://unstats.un.org/unsd/energy/balance/2014/05.pdf).
+
+    Parameters
+    ----------
+    sector : str
+        Sector to return factors for. Only ``"industry"`` is populated.
+
+    Returns
+    -------
+    dict
+        Mapping of fuel name to its conversion factor to TWh.
+    """
     # Create a dictionary with all the conversion factors from ktons or m3 to TWh based on https://unstats.un.org/unsd/energy/balance/2014/05.pdf
     if sector == "industry":
         fuels_conv_toTWh = {
@@ -1299,6 +1533,21 @@ def get_conv_factors(sector):
 
 
 def aggregate_fuels(sector):
+    """
+    Return the fuel names grouped by energy carrier category.
+
+    Parameters
+    ----------
+    sector : str
+        Sector for which to return the groupings (currently the same lists are
+        returned regardless of the value).
+
+    Returns
+    -------
+    tuple of list of str
+        Six lists in the order ``(gas_fuels, oil_fuels, biomass_fuels,
+        coal_fuels, heat, electricity)``.
+    """
     gas_fuels = [
         "Natural gas (including LNG)",  #
         "Natural Gas (including LNG)",  #
@@ -1560,6 +1809,23 @@ def branch(condition, then, otherwise=None):
 
 
 def rename_techs(label):
+    """
+    Normalise a technology label to a canonical, human-readable name.
+
+    Removes location prefixes (e.g. ``"residential "``), collapses labels that
+    contain a known keyword (e.g. ``"CHP"``) and applies explicit renamings
+    (e.g. ``"onwind"`` to ``"onshore wind"``).
+
+    Parameters
+    ----------
+    label : str
+        Original technology label.
+
+    Returns
+    -------
+    str
+        Renamed technology label.
+    """
     prefix_to_remove = [
         "residential ",
         "services ",
@@ -1780,6 +2046,18 @@ def sanitize_carriers(n, config):
 
 
 def sanitize_locations(n):
+    """
+    Fill missing bus coordinates and country codes from the ``location`` mapping.
+
+    For buses that carry a ``location`` column, zero ``x``/``y`` coordinates and
+    empty or missing ``country`` entries are replaced with the corresponding
+    values of the referenced location bus.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network whose ``buses`` table is updated in place.
+    """
     if "location" in n.buses.columns:
         n.buses["x"] = n.buses.x.where(n.buses.x != 0, n.buses.location.map(n.buses.x))
         n.buses["y"] = n.buses.y.where(n.buses.y != 0, n.buses.location.map(n.buses.y))

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -44,6 +44,7 @@ import time
 import zipfile
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import TracebackType
 
 import country_converter as coco
 import geopandas as gpd
@@ -77,7 +78,7 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 CONFIG_DEFAULT_PATH = os.path.join(BASE_DIR, "config.default.yaml")
 
 
-def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):
+def check_config_version(config: dict, fp_config: str = CONFIG_DEFAULT_PATH) -> None:
     """
     Check that a version of the local config.yaml matches to the actual config
     version as defined in config.default.yaml.
@@ -100,7 +101,7 @@ def check_config_version(config, fp_config=CONFIG_DEFAULT_PATH):
         )
 
 
-def update_cutout_config(config):
+def update_cutout_config(config: dict) -> dict:
     """
     Update renewable cutout settings in the configuration.
 
@@ -121,7 +122,11 @@ def update_cutout_config(config):
     return config
 
 
-def handle_exception(exc_type, exc_value, exc_traceback):
+def handle_exception(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: TracebackType | None,
+) -> None:
     """
     Customise errors traceback.
     """
@@ -148,7 +153,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
         )
 
 
-def copy_default_files():
+def copy_default_files() -> None:
     """
     Create a minimal ``config.yaml`` next to ``config.default.yaml`` if missing.
 
@@ -163,7 +168,7 @@ def copy_default_files():
         )
 
 
-def create_logger(logger_name, level=logging.INFO):
+def create_logger(logger_name: str, level: int = logging.INFO) -> logging.Logger:
     """
     Create a logger for a module and adds a handler needed to capture in logs
     traceback from exceptions emerging during the workflow.
@@ -176,7 +181,7 @@ def create_logger(logger_name, level=logging.INFO):
     return logger
 
 
-def read_osm_config(*args):
+def read_osm_config(*args: str) -> dict | str | tuple:
     """
     Read values from the regions config file based on provided key arguments.
 
@@ -221,7 +226,7 @@ def read_osm_config(*args):
         return tuple([osm_config[a] for a in args])
 
 
-def configure_logging(snakemake, skip_handlers=False):
+def configure_logging(snakemake, skip_handlers: bool = False) -> None:
     """
     Configure the basic behaviour for the logging module.
 
@@ -1066,7 +1071,7 @@ def create_country_list(input, iso_coding=True):
     return full_codes_list
 
 
-def get_last_commit_message(path):
+def get_last_commit_message(path: str | Path) -> str | None:
     """
     Function to get the last PyPSA-Earth Git commit message.
 
@@ -1095,10 +1100,10 @@ def get_last_commit_message(path):
 
 
 def update_config_dictionary(
-    config_dict,
-    parameter_key_to_fill="lines",
-    dict_to_use={"geometry": "first", "bounds": "first"},
-):
+    config_dict: dict,
+    parameter_key_to_fill: str = "lines",
+    dict_to_use: dict = {"geometry": "first", "bounds": "first"},
+) -> dict:
     """
     Ensure a configuration sub-dictionary exists and update it with defaults.
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 import zipfile
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import TracebackType
@@ -1500,7 +1501,7 @@ def locate_bus(
     return df
 
 
-def get_conv_factors(sector):
+def get_conv_factors(sector: str) -> dict:
     """
     Return conversion factors from mass/volume units to TWh per fuel.
 
@@ -1574,7 +1575,7 @@ def get_conv_factors(sector):
     return fuels_conv_toTWh
 
 
-def aggregate_fuels(sector):
+def aggregate_fuels(sector: str) -> tuple[list[str], ...]:
     """
     Return the fuel names grouped by energy carrier category.
 
@@ -1674,7 +1675,9 @@ def aggregate_fuels(sector):
     return gas_fuels, oil_fuels, biomass_fuels, coal_fuels, heat, electricity
 
 
-def safe_divide(numerator, denominator, default_value=np.nan):
+def safe_divide(
+    numerator: pd.DataFrame, denominator: float, default_value: float = np.nan
+) -> pd.DataFrame:
     """
     Safe division function that returns NaN when the denominator is zero.
     """
@@ -1687,7 +1690,7 @@ def safe_divide(numerator, denominator, default_value=np.nan):
         return pd.DataFrame(np.nan, index=numerator.index, columns=numerator.columns)
 
 
-def lossy_bidirectional_links(n, carrier):
+def lossy_bidirectional_links(n: pypsa.Network, carrier: str) -> None:
     """
     Split bidirectional links of type carrier into two unidirectional links to include transmission losses.
     """
@@ -1722,7 +1725,9 @@ def lossy_bidirectional_links(n, carrier):
     n.links["length_original"] = n.links["length_original"].fillna(n.links.length)
 
 
-def set_length_based_efficiency(n, carrier, bus_suffix, transmission_efficiency):
+def set_length_based_efficiency(
+    n: pypsa.Network, carrier: str, bus_suffix: str, transmission_efficiency: dict
+) -> None:
     """
     Set the efficiency of all links of type carrier in network n based on their length and the values specified in the config.
     Additionally add the length based electricity demand required for compression (if applicable).
@@ -1775,7 +1780,9 @@ def set_length_based_efficiency(n, carrier, bus_suffix, transmission_efficiency)
         n.links.loc[carrier_i, "efficiency2"] = -compression_per_1000km * lengths / 1e3
 
 
-def nearest_shape(n, path_shapes, crs, tolerance=100):
+def nearest_shape(
+    n: pypsa.Network, path_shapes: str, crs: dict, tolerance: int = 100
+) -> pypsa.Network:
     """
     Reassigns buses in the network `n` to the nearest country shape based on coordinates.
 
@@ -1831,7 +1838,7 @@ def nearest_shape(n, path_shapes, crs, tolerance=100):
     return n
 
 
-def branch(condition, then, otherwise=None):
+def branch(condition: bool, then, otherwise=None):
     """
     This is a placeholder function that exists in Snakemake versions > 8.3.0.
     It can be removed once Snakemake is updated to a compatible version.
@@ -1850,7 +1857,7 @@ def branch(condition, then, otherwise=None):
     return otherwise
 
 
-def rename_techs(label):
+def rename_techs(label: str) -> str:
     """
     Normalise a technology label to a canonical, human-readable name.
 
@@ -1931,7 +1938,7 @@ def rename_techs(label):
     return label
 
 
-def add_missing_carriers(n, carriers):
+def add_missing_carriers(n: pypsa.Network, carriers: Iterable) -> None:
     """
     Function to add missing carriers to the network without raising errors.
     """
@@ -2032,7 +2039,7 @@ def add_year_suffix_to_carriers(n: pypsa.Network) -> None:
     logger.info("Added year suffixes to carrier names for clustering")
 
 
-def sanitize_carriers(n, config):
+def sanitize_carriers(n: pypsa.Network, config: dict) -> None:
     """
     Sanitize the carrier information in a PyPSA Network object.
 
@@ -2087,7 +2094,7 @@ def sanitize_carriers(n, config):
     n.carriers["color"] = n.carriers.color.where(n.carriers.color != "", colors)
 
 
-def sanitize_locations(n):
+def sanitize_locations(n: pypsa.Network) -> None:
     """
     Fill missing bus coordinates and country codes from the ``location`` mapping.
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -269,7 +269,7 @@ def configure_logging(snakemake, skip_handlers: bool = False) -> None:
     logging.basicConfig(**kwargs, force=True)
 
 
-def pdbcast(v, h):
+def pdbcast(v: pd.Series, h: pd.Series) -> pd.DataFrame:
     """
     Broadcast two pandas Series into a DataFrame via an outer product.
 
@@ -291,7 +291,7 @@ def pdbcast(v, h):
     )
 
 
-def update_p_nom_max(n):
+def update_p_nom_max(n: pypsa.Network) -> None:
     """
     Ensure ``p_nom_max`` is at least ``p_nom_min`` for all generators.
 
@@ -313,7 +313,7 @@ def update_p_nom_max(n):
     n.generators.p_nom_max = n.generators[["p_nom_min", "p_nom_max"]].max(1)
 
 
-def aggregate_p_nom(n):
+def aggregate_p_nom(n: pypsa.Network) -> pd.Series:
     """
     Aggregate optimal nominal power capacity per carrier.
 
@@ -338,7 +338,7 @@ def aggregate_p_nom(n):
     )
 
 
-def aggregate_p(n):
+def aggregate_p(n: pypsa.Network) -> pd.Series:
     """
     Aggregate dispatched power per carrier.
 
@@ -363,7 +363,7 @@ def aggregate_p(n):
     )
 
 
-def aggregate_e_nom(n):
+def aggregate_e_nom(n: pypsa.Network) -> pd.Series:
     """
     Aggregate optimal nominal energy storage capacity per carrier.
 
@@ -388,7 +388,7 @@ def aggregate_e_nom(n):
     )
 
 
-def aggregate_p_curtailed(n):
+def aggregate_p_curtailed(n: pypsa.Network) -> pd.Series:
     """
     Aggregate curtailed power per carrier.
 
@@ -422,7 +422,12 @@ def aggregate_p_curtailed(n):
     )
 
 
-def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
+def aggregate_costs(
+    n: pypsa.Network,
+    flatten: bool = False,
+    opts: dict | None = None,
+    existing_only: bool = False,
+) -> pd.Series:
     """
     Aggregate capital and marginal system costs per component and carrier.
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1298,7 +1298,9 @@ def create_dummy_data(n: pypsa.Network, sector: str, carriers: list) -> pd.DataF
 #     return energy_totals
 
 
-def cycling_shift(df: pd.DataFrame | pd.Series, steps: int = 1) -> pd.DataFrame | pd.Series:
+def cycling_shift(
+    df: pd.DataFrame | pd.Series, steps: int = 1
+) -> pd.DataFrame | pd.Series:
     """
     Cyclic shift on index of pd.Series|pd.DataFrame by number of steps.
     """

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -858,7 +858,7 @@ def country_name_2_two_digits(country_name: str) -> str:
     return full_name
 
 
-def read_csv_nafix(file, **kwargs):
+def read_csv_nafix(file: str | Path, **kwargs) -> pd.DataFrame:
     "Function to open a csv as pandas file and standardize the na value"
     if "keep_default_na" not in kwargs:
         kwargs["keep_default_na"] = False
@@ -876,7 +876,7 @@ def read_csv_nafix(file, **kwargs):
         return pd.DataFrame()
 
 
-def to_csv_nafix(df, path, **kwargs):
+def to_csv_nafix(df: pd.DataFrame, path: str | Path | None, **kwargs):
     """
     Write a DataFrame to CSV using the project's standard NA representation.
 
@@ -950,7 +950,7 @@ def add_transform_iso3(
     return df
 
 
-def save_to_geojson(df, fn):
+def save_to_geojson(df: gpd.GeoDataFrame, fn: str | Path) -> None:
     """
     Save a (Geo)DataFrame to a GeoJSON file, overwriting any existing file.
 
@@ -977,7 +977,9 @@ def save_to_geojson(df, fn):
         df.to_file(fn, driver="GeoJSON")
 
 
-def read_geojson(fn, cols=[], dtype=None, crs="EPSG:4326"):
+def read_geojson(
+    fn: str | Path, cols: list = [], dtype: dict | None = None, crs: str = "EPSG:4326"
+) -> gpd.GeoDataFrame:
     """
     Function to read a geojson file fn. When the file is empty, then an empty
     GeoDataFrame is returned having columns cols, the specified crs and the


### PR DESCRIPTION
## Closes #1825

## Changes proposed in this Pull Request

Documentation and typing improvements to `scripts/_helpers.py`:

- Add a module-level docstring describing the module and grouping its helpers
  (configuration and logging, network aggregation, country handling, I/O,
  Snakemake helpers, sector-coupling helpers).
- Add NumPy-style docstrings to the 16 functions that were still missing one
  (`copy_default_files`, `pdbcast`, `update_p_nom_max`, `aggregate_p_nom`,
  `aggregate_p`, `aggregate_e_nom`, `aggregate_p_curtailed`, `aggregate_costs`,
  `to_csv_nafix`, `save_to_geojson`, `update_config_dictionary`,
  `create_dummy_data`, `get_conv_factors`, `aggregate_fuels`, `rename_techs`,
  `sanitize_locations`).
- Add Python 3.10+ type hints to the function signatures (the second part of
  #1825). A few signatures are left partially typed where a concrete type would
  be inaccurate; `mypy scripts/ --ignore-missing-imports --no-strict-optional`
  reports no issues.

The style follows the conventions noted in the issue (module sections as in
`add_electricity.py`, NumPy-style as in `build_shapes.py`). The SPDX header is
left untouched.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
