### PR TITLE
Bug Fix: Aggregation strategies scope limited to if-else block

### DIFF
--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -751,7 +751,7 @@ if __name__ == "__main__":
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None
-    
+
     aggregation_strategies = snakemake.params.aggregation_strategies
 
     if n_clusters == len(n.buses) and not alternative_clustering:
@@ -776,7 +776,6 @@ if __name__ == "__main__":
                 x == v
             ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
-
 
         # Aggregation strategies must be set for all columns
         update_config_dictionary(

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -751,6 +751,8 @@ if __name__ == "__main__":
     else:
         n_clusters = int(snakemake.wildcards.clusters)
         aggregate_carriers = None
+    
+    aggregation_strategies = snakemake.params.aggregation_strategies
 
     if n_clusters == len(n.buses) and not alternative_clustering:
         # Fast-path if no clustering is necessary
@@ -775,7 +777,6 @@ if __name__ == "__main__":
             ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
-        aggregation_strategies = snakemake.params.aggregation_strategies
 
         # Aggregation strategies must be set for all columns
         update_config_dictionary(


### PR DESCRIPTION
# Closes # (if applicable)

## Changes proposed in this Pull Request
Bug: `aggregation_strategies` was defined inside the else branch of the `clustering if/elif/else block`, but used unconditionally after it at line 842 `(groupby_bus_carrier(..., aggregation_strategies)` when `foresight == "overnight")`.

When `clusters == "all"`, `n_clusters` equals `len(n.buses)`, so the code takes the fast-path branch (`if n_clusters == len(n.buses`) and not `alternative_clustering`) — which sets up clustering but never defines `aggregation_strategies`. The subsequent call to `groupby_bus_carrier` then raises a `NameError`.

Fix: Move `aggregation_strategies = snakemake.params.aggregation_strategies` to before the `if/elif/else` block so it is always defined regardless of which clustering branch is taken. The `update_config_dictionary` calls for lines and buses remain in the else branch since they are only needed by `clustering_for_n_clusters`

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
