### PR TITLE
Replace deprecated UNCTAD urban population download endpoint

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -38,6 +38,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Replace deprecated UNCTAD urban population download endpoint in `prepare_urban_percent.py` [PR #1881](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1881)
+
 * Remove unused `add_extendable_generators` function in `add_electricity.py` script [PR #1854](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1854)
 
 * Adjusted the code to be more robust [#1812](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1812)

--- a/scripts/prepare_urban_percent.py
+++ b/scripts/prepare_urban_percent.py
@@ -25,7 +25,7 @@ def download_urban_percent():
     https://unctadstat.unctad.org/datacentre/
     as a .7z file. The dataset contains urban percent for most countries from 1950 and predictions until 2050.
     """
-    url = "https://unctadstat-api.unctad.org/api/reportMetadata/US.PopTotal/bulkfile/355/en"
+    url = "https://unctadstat-api.unctad.org/bulkdownload/US.PopTotal/US_PopTotal"
 
     # Make a GET request to the URL
     response = requests.get(url)


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR updates the download URL used in `prepare_urban_percent.py`. The previous UNCTAD bulk download endpoint is no longer available and now returns:
```
{"Error":"bulk file not available with id 355"}
```
This change replaces the deprecated endpoint with the current UNCTAD bulk download permalink for the *Population: Total - Annual* dataset.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
